### PR TITLE
feat: Add -> operator which get property value from vertex

### DIFF
--- a/src/include/catalog/pg_operator.h
+++ b/src/include/catalog/pg_operator.h
@@ -1820,4 +1820,8 @@ DESCR("delete array element");
 DATA(insert OID = 3287 (  "#-"	   PGNSP PGUID b f f 3802 1009 3802 0 0 jsonb_delete_path - - ));
 DESCR("delete path");
 
+/* operators for graph */
+DATA(insert OID = 3319 ( "->"	PGNSP PGUID b f f 3308 25 3802 0 0 vertex_prop - - ));
+DESCR("get vertex project value");
+
 #endif   /* PG_OPERATOR_H */

--- a/src/include/catalog/pg_proc.h
+++ b/src/include/catalog/pg_proc.h
@@ -5326,12 +5326,14 @@ DATA(insert OID = 6014 ( pg_show_replication_origin_status PGNSP PGUID 12 1 100 
 DESCR("get progress for all replication origins");
 
 /* graphs */
-DATA(insert OID =  3315 ( vertex_in		PGNSP PGUID 12 1 0 0 0 f f f f f f i 1 0 3308 "2275" _null_ _null_ _null_ _null_ _null_ vertex_in _null_ _null_ _null_ ));
+DATA(insert OID = 3315 ( vertex_in		PGNSP PGUID 12 1 0 0 0 f f f f f f i 1 0 3308 "2275" _null_ _null_ _null_ _null_ _null_ vertex_in _null_ _null_ _null_ ));
 DESCR("I/O");
-DATA(insert OID =  3316 ( vertex_out	PGNSP PGUID 12 1 0 0 0 f f f f t f i 1 0 2275 "3308" _null_ _null_ _null_ _null_ _null_ vertex_out _null_ _null_ _null_ ));
+DATA(insert OID = 3316 ( vertex_out		PGNSP PGUID 12 1 0 0 0 f f f f t f i 1 0 2275 "3308" _null_ _null_ _null_ _null_ _null_ vertex_out _null_ _null_ _null_ ));
 DESCR("I/O");
-DATA(insert OID =  3317 ( vertex		PGNSP PGUID 12 1 0 0 0 f f f f f f i 3 0 3308 "19 20 3802" _null_ _null_ "{label, vid, prop_map}" _null_ _null_ vertex_constructor _null_ _null_ _null_ ));
+DATA(insert OID = 3317 ( vertex			PGNSP PGUID 12 1 0 0 0 f f f f f f i 3 0 3308 "19 20 3802" _null_ _null_ "{label, vid, prop_map}" _null_ _null_ vertex_constructor _null_ _null_ _null_ ));
 DESCR("build a vertex");
+DATA(insert OID = 3318 ( vertex_prop	PGNSP PGUID 12 1 0 0 0 f f f f t f i 2 0 3802 "3308 25" _null_ _null_ "{prop_key}" _null_ _null_ vertex_prop _null_ _null_ _null_ ));
+DESCR("get property value from vertex as jsonb with property key");
 
 /*
  * Symbolic values for provolatile column: these indicate whether the result

--- a/src/include/utils/graph.h
+++ b/src/include/utils/graph.h
@@ -31,5 +31,6 @@ typedef struct Vertex
 extern Datum vertex_in(PG_FUNCTION_ARGS);
 extern Datum vertex_out(PG_FUNCTION_ARGS);
 extern Datum vertex_constructor(PG_FUNCTION_ARGS);
+extern Datum vertex_prop(PG_FUNCTION_ARGS);
 
 #endif	/* GRAPH_H */


### PR DESCRIPTION
It is preferable to use `.` to get a property value from the given
vertex. But it is hard to use `.` because the scanner treats `.` as a
character, not an operator, and indirection rule uses `.` for the same
purpose. So, we add it as a vertex -> operator first.
The vertex -> operator actually calls the function for jsonb -> operator
with a Jsonb in the vertex and a property key as arguments.