### PR TITLE
feat(cypher): Implement pattern grammar

### DIFF
--- a/src/backend/nodes/copyfuncs.c
+++ b/src/backend/nodes/copyfuncs.c
@@ -4166,6 +4166,20 @@ _copyCypherNode(const CypherNode *from)
 	return newnode;
 }
 
+static CypherRel *
+_copyCypherRel(const CypherRel *from)
+{
+	CypherRel *newnode = makeNode(CypherRel);
+
+	COPY_SCALAR_FIELD(direction);
+	COPY_STRING_FIELD(variable);
+	COPY_NODE_FIELD(types);
+	COPY_NODE_FIELD(varlen);
+	COPY_STRING_FIELD(prop_map);
+
+	return newnode;
+}
+
 /* ****************************************************************
  *					pg_list.h copy functions
  * ****************************************************************
@@ -5042,6 +5056,9 @@ copyObject(const void *from)
 			break;
 		case T_CypherNode:
 			retval = _copyCypherNode(from);
+			break;
+		case T_CypherRel:
+			retval = _copyCypherRel(from);
 			break;
 
 		default:

--- a/src/backend/nodes/equalfuncs.c
+++ b/src/backend/nodes/equalfuncs.c
@@ -2615,6 +2615,18 @@ _equalCypherNode(const CypherNode *a, const CypherNode *b)
 	return true;
 }
 
+static bool
+_equalCypherRel(const CypherRel *a, const CypherRel *b)
+{
+	COMPARE_SCALAR_FIELD(direction);
+	COMPARE_STRING_FIELD(variable);
+	COMPARE_NODE_FIELD(types);
+	COMPARE_NODE_FIELD(varlen);
+	COMPARE_STRING_FIELD(prop_map);
+
+	return true;
+}
+
 /*
  * Stuff from pg_list.h
  */
@@ -3369,6 +3381,9 @@ equal(const void *a, const void *b)
 			break;
 		case T_CypherNode:
 			retval = _equalCypherNode(a, b);
+			break;
+		case T_CypherRel:
+			retval = _equalCypherRel(a, b);
 			break;
 
 		default:

--- a/src/backend/nodes/outfuncs.c
+++ b/src/backend/nodes/outfuncs.c
@@ -3002,6 +3002,18 @@ _outCypherNode(StringInfo str, const CypherNode *node)
 	WRITE_STRING_FIELD(prop_map);
 }
 
+static void
+_outCypherRel(StringInfo str, const CypherRel *node)
+{
+	WRITE_NODE_TYPE("CYPHERREL");
+
+	WRITE_INT_FIELD(direction);
+	WRITE_STRING_FIELD(variable);
+	WRITE_NODE_FIELD(types);
+	WRITE_NODE_FIELD(varlen);
+	WRITE_STRING_FIELD(prop_map);
+}
+
 /*
  * _outNode -
  *	  converts a Node into ascii string and append it to 'str'
@@ -3546,6 +3558,9 @@ _outNode(StringInfo str, const void *obj)
 				break;
 			case T_CypherNode:
 				_outCypherNode(str, obj);
+				break;
+			case T_CypherRel:
+				_outCypherRel(str, obj);
 				break;
 
 			default:

--- a/src/include/nodes/nodes.h
+++ b/src/include/nodes/nodes.h
@@ -432,6 +432,7 @@ typedef enum NodeTag
 	T_CypherReturnClause,
 	T_CypherPattern,
 	T_CypherNode,
+	T_CypherRel,
 
 	/*
 	 * TAGS FOR REPLICATION GRAMMAR PARSE NODES (replnodes.h)

--- a/src/include/nodes/parsenodes.h
+++ b/src/include/nodes/parsenodes.h
@@ -3116,4 +3116,18 @@ typedef struct CypherNode
 	char	   *prop_map;	/* JSON object string */
 } CypherNode;
 
+#define CYPHER_REL_DIR_NONE		0
+#define CYPHER_REL_DIR_LEFT		(1 << 0)
+#define CYPHER_REL_DIR_RIGHT	(1 << 1)
+
+typedef struct CypherRel
+{
+	NodeTag		type;
+	uint32		direction;	/* bitmask of directions (see above) */
+	char	   *variable;
+	List	   *types;		/* ORed types */
+	Node	   *varlen;		/* variable length relationships (A_Indices) */
+	char	   *prop_map;	/* JSON object string */
+} CypherRel;
+
 #endif   /* PARSENODES_H */


### PR DESCRIPTION
Now, the parser can parse Cypher's pattern. However, there are some
workarounds due to the behavior of the scanner. First, we cannot parse
a very simple relationship `--` because the scanner treats it as an
inline comment. So, current implementation only can support it through
`-[]-`. Also, right direction `->` and `|` which connects multiple
relationship type constraints are treated as an operator. So, we use
`Op` token in the rule instead, and if the parser detects a parsed
token other than `->` and `|`, then it reports a syntax error.