### PR TITLE
feat: Add `edge` type for Cypher relationships

### DIFF
--- a/src/backend/utils/adt/graph.c
+++ b/src/backend/utils/adt/graph.c
@@ -13,6 +13,7 @@
 #include "utils/builtins.h"
 #include "utils/graph.h"
 #include "utils/json.h"
+#include "utils/lsyscache.h"
 
 Datum
 vertex_in(PG_FUNCTION_ARGS)
@@ -27,34 +28,52 @@ vertex_in(PG_FUNCTION_ARGS)
 Datum
 vertex_out(PG_FUNCTION_ARGS)
 {
-	Vertex	   *v = PG_GETARG_VERTEX(0);
-	StringInfoData	si;
+	Vertex *v = PG_GETARG_VERTEX(0);
+	StringInfoData si;
 
 	initStringInfo(&si);
-	appendStringInfo(&si, "Node[%s:" INT64_FORMAT "] ",
-					 NameStr(v->label), v->vid);
+	appendStringInfo(&si, "Node[%u:" INT64_FORMAT "]", v->id.oid, v->id.vid);
 	JsonbToCString(&si, &v->prop_map.root, VARSIZE(&v->prop_map));
 
 	PG_RETURN_CSTRING(si.data);
 }
 
+static Jsonb *
+build_jsonb_empty_object(void)
+{
+	FunctionCallInfoData locfcinfo;
+	Datum result;
+
+	InitFunctionCallInfoData(locfcinfo, NULL, 0, InvalidOid, NULL, NULL);
+	result = jsonb_build_object_noargs(&locfcinfo);
+	/* the result never be NULL, skip NULL check */
+	Assert(!locfcinfo.isnull);
+
+	return (Jsonb *) result;
+}
+
 Datum
 vertex_constructor(PG_FUNCTION_ARGS)
 {
-	Name		label = PG_GETARG_NAME(0);
+	Oid			oid = PG_GETARG_OID(0);
 	int64		vid = PG_GETARG_INT64(1);
-	Jsonb	   *prop_map = PG_GETARG_JSONB(2);
+	Jsonb	   *prop_map;
 	Size		len;
 	Vertex	   *v;
 
+	if (PG_ARGISNULL(0))
+		ereport(ERROR,
+				(errcode(ERRCODE_INVALID_PARAMETER_VALUE),
+				 errmsg("vertex label OID must not be null")));
 	if (PG_ARGISNULL(1))
 		ereport(ERROR,
 				(errcode(ERRCODE_INVALID_PARAMETER_VALUE),
 				 errmsg("vertex ID must not be null")));
+
 	if (PG_ARGISNULL(2))
-		ereport(ERROR,
-				(errcode(ERRCODE_INVALID_PARAMETER_VALUE),
-				 errmsg("property map must not be null")));
+		prop_map = build_jsonb_empty_object();
+	else
+		prop_map = PG_GETARG_JSONB(2);
 
 	/* property map should be a JSON object */
 	if (!JB_ROOT_IS_OBJECT(prop_map))
@@ -68,9 +87,8 @@ vertex_constructor(PG_FUNCTION_ARGS)
 	MemSetLoop(v, 0, offsetof(Vertex, prop_map));
 	SET_VARSIZE(v, len);
 
-	if (!PG_ARGISNULL(0))
-		namecpy(&v->label, label);
-	v->vid = vid;
+	v->id.oid = oid;
+	v->id.vid = vid;
 	memcpy(&v->prop_map, prop_map, VARSIZE(prop_map));
 
 	PG_RETURN_POINTER(v);
@@ -80,7 +98,7 @@ Datum
 vertex_prop(PG_FUNCTION_ARGS)
 {
 	Vertex	   *v = PG_GETARG_VERTEX(0);
-	text	   *label = PG_GETARG_TEXT_P(1);
+	text	   *key = PG_GETARG_TEXT_P(1);
 	FunctionCallInfoData locfcinfo;
 	Datum		result;
 
@@ -88,7 +106,119 @@ vertex_prop(PG_FUNCTION_ARGS)
 							 PG_GET_COLLATION(), NULL, NULL);
 
 	locfcinfo.arg[0] = PointerGetDatum(&v->prop_map);
-	locfcinfo.arg[1] = PointerGetDatum(label);
+	locfcinfo.arg[1] = PointerGetDatum(key);
+	locfcinfo.argnull[0] = false;
+	locfcinfo.argnull[1] = PG_ARGISNULL(1);
+
+	result = jsonb_object_field(&locfcinfo);
+
+	if (locfcinfo.isnull)
+		PG_RETURN_NULL();
+
+	return result;
+}
+
+Datum
+edge_in(PG_FUNCTION_ARGS)
+{
+	ereport(ERROR,
+			(errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
+			 errmsg("cannot accept a value of type edge")));
+
+	PG_RETURN_VOID();
+}
+
+Datum
+edge_out(PG_FUNCTION_ARGS)
+{
+	GraphEdge  *e = PG_GETARG_EDGE(0);
+	char	   *label;
+	StringInfoData si;
+
+	label = get_rel_name(e->oid);
+	if (label == NULL)
+		label = "?";
+
+	initStringInfo(&si);
+	appendStringInfo(&si, ":%s", label);
+	JsonbToCString(&si, &e->prop_map.root, VARSIZE(&e->prop_map));
+
+	PG_RETURN_CSTRING(si.data);
+}
+
+Datum
+edge_constructor(PG_FUNCTION_ARGS)
+{
+	Oid			oid = PG_GETARG_OID(0);
+	Oid			vin_oid = PG_GETARG_OID(1);
+	int64		vin_vid = PG_GETARG_INT64(2);
+	Oid			vout_oid = PG_GETARG_OID(3);
+	int64		vout_vid = PG_GETARG_INT64(4);
+	Jsonb	   *prop_map;
+	Size		len;
+	GraphEdge  *e;
+
+	if (PG_ARGISNULL(0))
+		ereport(ERROR,
+				(errcode(ERRCODE_INVALID_PARAMETER_VALUE),
+				 errmsg("edge type OID must not be null")));
+	if (PG_ARGISNULL(1))
+		ereport(ERROR,
+				(errcode(ERRCODE_INVALID_PARAMETER_VALUE),
+				 errmsg("vertex(in) label OID must not be null")));
+	if (PG_ARGISNULL(2))
+		ereport(ERROR,
+				(errcode(ERRCODE_INVALID_PARAMETER_VALUE),
+				 errmsg("vertex(in) ID must not be null")));
+	if (PG_ARGISNULL(3))
+		ereport(ERROR,
+				(errcode(ERRCODE_INVALID_PARAMETER_VALUE),
+				 errmsg("vertex(out) label OID must not be null")));
+	if (PG_ARGISNULL(4))
+		ereport(ERROR,
+				(errcode(ERRCODE_INVALID_PARAMETER_VALUE),
+				 errmsg("vertex(out) ID must not be null")));
+
+	if (PG_ARGISNULL(5))
+		prop_map = build_jsonb_empty_object();
+	else
+		prop_map = PG_GETARG_JSONB(5);
+
+	/* property map should be a JSON object */
+	if (!JB_ROOT_IS_OBJECT(prop_map))
+		ereport(ERROR,
+				(errcode(ERRCODE_INVALID_PARAMETER_VALUE),
+				 errmsg("property map must be a binary JSON object")));
+
+	len = offsetof(GraphEdge, prop_map) + VARSIZE(prop_map);
+
+	e = (GraphEdge *) palloc(len);
+	MemSetLoop(e, 0, offsetof(GraphEdge, prop_map));
+	SET_VARSIZE(e, len);
+
+	e->oid = oid;
+	e->vin.oid = vin_oid;
+	e->vin.vid = vin_vid;
+	e->vout.oid = vout_oid;
+	e->vout.vid = vout_vid;
+	memcpy(&e->prop_map, prop_map, VARSIZE(prop_map));
+
+	PG_RETURN_POINTER(e);
+}
+
+Datum
+edge_prop(PG_FUNCTION_ARGS)
+{
+	GraphEdge  *e = PG_GETARG_EDGE(0);
+	text	   *key = PG_GETARG_TEXT_P(1);
+	FunctionCallInfoData locfcinfo;
+	Datum		result;
+
+	InitFunctionCallInfoData(locfcinfo, NULL, 2,
+							 PG_GET_COLLATION(), NULL, NULL);
+
+	locfcinfo.arg[0] = PointerGetDatum(&e->prop_map);
+	locfcinfo.arg[1] = PointerGetDatum(key);
 	locfcinfo.argnull[0] = false;
 	locfcinfo.argnull[1] = PG_ARGISNULL(1);
 

--- a/src/include/catalog/pg_operator.h
+++ b/src/include/catalog/pg_operator.h
@@ -1822,6 +1822,8 @@ DESCR("delete path");
 
 /* operators for graph */
 DATA(insert OID = 3319 ( "->"	PGNSP PGUID b f f 3308 25 3802 0 0 vertex_prop - - ));
-DESCR("get vertex project value");
+DESCR("get vertex property value");
+DATA(insert OID = 3324 ( "->"	PGNSP PGUID b f f 3309 25 3802 0 0 edge_prop - - ));
+DESCR("get edge property value");
 
 #endif   /* PG_OPERATOR_H */

--- a/src/include/catalog/pg_proc.h
+++ b/src/include/catalog/pg_proc.h
@@ -5325,15 +5325,23 @@ DESCR("get an individual replication origin's replication progress");
 DATA(insert OID = 6014 ( pg_show_replication_origin_status PGNSP PGUID 12 1 100 0 0 f f f f f t v 0 0 2249 "" "{26,25,3220,3220}" "{o,o,o,o}" "{local_id, external_id, remote_lsn, local_lsn}" _null_ _null_ pg_show_replication_origin_status _null_ _null_ _null_ ));
 DESCR("get progress for all replication origins");
 
-/* graphs */
+/* graph */
 DATA(insert OID = 3315 ( vertex_in		PGNSP PGUID 12 1 0 0 0 f f f f f f i 1 0 3308 "2275" _null_ _null_ _null_ _null_ _null_ vertex_in _null_ _null_ _null_ ));
 DESCR("I/O");
 DATA(insert OID = 3316 ( vertex_out		PGNSP PGUID 12 1 0 0 0 f f f f t f i 1 0 2275 "3308" _null_ _null_ _null_ _null_ _null_ vertex_out _null_ _null_ _null_ ));
 DESCR("I/O");
-DATA(insert OID = 3317 ( vertex			PGNSP PGUID 12 1 0 0 0 f f f f f f i 3 0 3308 "19 20 3802" _null_ _null_ "{label, vid, prop_map}" _null_ _null_ vertex_constructor _null_ _null_ _null_ ));
+DATA(insert OID = 3317 ( vertex			PGNSP PGUID 12 1 0 0 0 f f f f f f i 3 0 3308 "2205 20 3802" _null_ _null_ "{oid, vid, prop_map}" _null_ _null_ vertex_constructor _null_ _null_ _null_ ));
 DESCR("build a vertex");
 DATA(insert OID = 3318 ( vertex_prop	PGNSP PGUID 12 1 0 0 0 f f f f t f i 2 0 3802 "3308 25" _null_ _null_ "{prop_key}" _null_ _null_ vertex_prop _null_ _null_ _null_ ));
 DESCR("get property value from vertex as jsonb with property key");
+DATA(insert OID = 3320 ( edge_in		PGNSP PGUID 12 1 0 0 0 f f f f f f i 1 0 3309 "2275" _null_ _null_ _null_ _null_ _null_ edge_in _null_ _null_ _null_ ));
+DESCR("I/O");
+DATA(insert OID = 3321 ( edge_out		PGNSP PGUID 12 1 0 0 0 f f f f t f i 1 0 2275 "3309" _null_ _null_ _null_ _null_ _null_ edge_out _null_ _null_ _null_ ));
+DESCR("I/O");
+DATA(insert OID = 3322 ( edge			PGNSP PGUID 12 1 0 0 0 f f f f f f i 6 0 3309 "2205 2205 20 2205 20 3802" _null_ _null_ "{oid, vin_oid, vin_vid, vout_oid, vout_vid, prop_map}" _null_ _null_ edge_constructor _null_ _null_ _null_ ));
+DESCR("build an edge");
+DATA(insert OID = 3323 ( edge_prop		PGNSP PGUID 12 1 0 0 0 f f f f t f i 2 0 3802 "3309 25" _null_ _null_ "{prop_key}" _null_ _null_ edge_prop _null_ _null_ _null_ ));
+DESCR("get property value from edge as jsonb with property key");
 
 /*
  * Symbolic values for provolatile column: these indicate whether the result

--- a/src/include/catalog/pg_type.h
+++ b/src/include/catalog/pg_type.h
@@ -655,7 +655,9 @@ DATA(insert OID = 3927 ( _int8range		PGNSP PGUID  -1 f b A f t \054 0 3926 0 arr
 DATA(insert OID = 3308 ( vertex		PGNSP PGUID -1 f b U f t \054 0 0 0 vertex_in vertex_out - - - - - d x f 0 -1 0 0 _null_ _null_ _null_ ));
 DESCR("vertex");
 #define VERTEXOID	3308
-/* TODO: DATA(insert OID = 3309 ( edge ... */
+DATA(insert OID = 3309 ( edge		PGNSP PGUID -1 f b U f t \054 0 0 0 edge_in edge_out - - - - - d x f 0 -1 0 0 _null_ _null_ _null_ ));
+DESCR("edge");
+#define EDGEOID		3309
 
 /*
  * pseudo-types

--- a/src/include/utils/graph.h
+++ b/src/include/utils/graph.h
@@ -17,14 +17,20 @@
 
 #define PG_GETARG_VERTEX(n)	((Vertex *) PG_GETARG_VARLENA_P(n))
 
+typedef struct VertexId
+{
+	Oid			oid;		/* node label (relation) */
+	int32		pad_;		/* for 8-byte alignment */
+	int64		vid;		/* int8 (or BIGINT) */
+} VertexId;
+
 typedef struct Vertex
 {
 	int32		vl_len_;	/* varlena header (do not touch directly!) */
 
 	int32		pad_;		/* for 8-byte alignment */
 
-	NameData	label;		/* name */
-	int64		vid;		/* int8 (or BIGINT) */
+	VertexId	id;
 	Jsonb		prop_map;	/* jsonb; type of root should be object */
 } Vertex;
 
@@ -32,5 +38,22 @@ extern Datum vertex_in(PG_FUNCTION_ARGS);
 extern Datum vertex_out(PG_FUNCTION_ARGS);
 extern Datum vertex_constructor(PG_FUNCTION_ARGS);
 extern Datum vertex_prop(PG_FUNCTION_ARGS);
+
+#define PG_GETARG_EDGE(n)	((GraphEdge *) PG_GETARG_VARLENA_P(n))
+
+typedef struct GraphEdge
+{
+	int32		vl_len_;	/* varlena header (do not touch directly!) */
+
+	Oid			oid;		/* relationship type (relation) */
+	VertexId	vin;
+	VertexId	vout;
+	Jsonb		prop_map;	/* jsonb; type of root should be object */
+} GraphEdge;
+
+extern Datum edge_in(PG_FUNCTION_ARGS);
+extern Datum edge_out(PG_FUNCTION_ARGS);
+extern Datum edge_constructor(PG_FUNCTION_ARGS);
+extern Datum edge_prop(PG_FUNCTION_ARGS);
 
 #endif	/* GRAPH_H */


### PR DESCRIPTION
Overall implementation of edge type is very similar to vertex type.
We use `GraphEdge` as the struct name of edge type because `Edge` is
already taken.

Some notable modifications are:
* struct `VertexId` is added to point a unique vertex; (oid, vid) pair
* now, vertex type uses `VertexId` instead of label NameData and vid