### PR TITLE
feat: Add Catalog table 'ag_inherits'

### DIFF
--- a/src/backend/catalog/Makefile
+++ b/src/backend/catalog/Makefile
@@ -42,7 +42,7 @@ POSTGRES_BKI_SRCS = $(addprefix $(top_srcdir)/src/include/catalog/,\
 	pg_foreign_table.h pg_policy.h pg_replication_origin.h \
 	pg_default_acl.h pg_seclabel.h pg_shseclabel.h \
 	pg_collation.h pg_range.h pg_transform.h \
-	toasting.h indexing.h ag_label.h \
+	toasting.h indexing.h ag_label.h ag_inherits.h \
     )
 
 # location of Catalog.pm

--- a/src/backend/catalog/dependency.c
+++ b/src/backend/catalog/dependency.c
@@ -55,6 +55,7 @@
 #include "catalog/pg_ts_template.h"
 #include "catalog/pg_type.h"
 #include "catalog/pg_user_mapping.h"
+#include "catalog/ag_label.h"
 #include "commands/comment.h"
 #include "commands/defrem.h"
 #include "commands/event_trigger.h"
@@ -2316,6 +2317,7 @@ getObjectClass(const ObjectAddress *object)
 	switch (object->classId)
 	{
 		case RelationRelationId:
+		case LabelRelationId:
 			/* caller must check objectSubId */
 			return OCLASS_CLASS;
 

--- a/src/backend/catalog/pg_inherits.c
+++ b/src/backend/catalog/pg_inherits.c
@@ -23,6 +23,7 @@
 #include "access/heapam.h"
 #include "access/htup_details.h"
 #include "catalog/indexing.h"
+#include "catalog/ag_inherits.h"
 #include "catalog/pg_inherits.h"
 #include "catalog/pg_inherits_fn.h"
 #include "parser/parse_type.h"
@@ -46,7 +47,7 @@ static int	oid_cmp(const void *p1, const void *p2);
  * against possible DROPs of child relations.
  */
 List *
-find_inheritance_children(Oid parentrelId, LOCKMODE lockmode)
+find_inheritance_children(Oid classId, Oid parentrelId, LOCKMODE lockmode)
 {
 	List	   *list = NIL;
 	Relation	relation;
@@ -54,6 +55,7 @@ find_inheritance_children(Oid parentrelId, LOCKMODE lockmode)
 	ScanKeyData key[1];
 	HeapTuple	inheritsTuple;
 	Oid			inhrelid;
+	Oid			anum_inhparent;
 	Oid		   *oidarr;
 	int			maxoids,
 				numoids,
@@ -67,16 +69,23 @@ find_inheritance_children(Oid parentrelId, LOCKMODE lockmode)
 		return NIL;
 
 	/*
-	 * Scan pg_inherits and build a working array of subclass OIDs.
+	 * Scan pg_inherits/ag_inherits and build a working array of subclass OIDs.
 	 */
 	maxoids = 32;
 	oidarr = (Oid *) palloc(maxoids * sizeof(Oid));
 	numoids = 0;
 
-	relation = heap_open(InheritsRelationId, AccessShareLock);
+	relation = heap_open(classId, AccessShareLock);
+
+	if (classId == InheritsRelationId)
+		anum_inhparent = Anum_pg_inherits_inhparent;
+	else if (classId == InheritsLabelId)
+		anum_inhparent = Anum_ag_inherits_inhparent;
+	else /* shouldn't happen */
+		elog(ERROR, "Access to Inheritance catalog with invalid OID %d", classid);
 
 	ScanKeyInit(&key[0],
-				Anum_pg_inherits_inhparent,
+				anum_inhparent,
 				BTEqualStrategyNumber, F_OIDEQ,
 				ObjectIdGetDatum(parentrelId));
 
@@ -85,7 +94,13 @@ find_inheritance_children(Oid parentrelId, LOCKMODE lockmode)
 
 	while ((inheritsTuple = systable_getnext(scan)) != NULL)
 	{
-		inhrelid = ((Form_pg_inherits) GETSTRUCT(inheritsTuple))->inhrelid;
+		if (classId == InheritsRelationId)
+			inhrelid = ((Form_pg_inherits) GETSTRUCT(inheritsTuple))->inhrelid;
+		else if (classId == InheritsLabelId)
+			inhrelid = ((Form_ag_inherits) GETSTRUCT(inheritsTuple))->inhrelid;
+		else
+			inhrelid = 0;
+
 		if (numoids >= maxoids)
 		{
 			maxoids *= 2;
@@ -179,7 +194,8 @@ find_all_inheritors(Oid parentrelId, LOCKMODE lockmode, List **numparents)
 		ListCell   *lc;
 
 		/* Get the direct children of this rel */
-		currentchildren = find_inheritance_children(currentrel, lockmode);
+		currentchildren = find_inheritance_children(InheritsRelationId,
+													currentrel, lockmode);
 
 		/*
 		 * Add to the queue only those children not already seen. This avoids

--- a/src/backend/commands/lockcmds.c
+++ b/src/backend/commands/lockcmds.c
@@ -16,6 +16,7 @@
 
 #include "access/heapam.h"
 #include "catalog/namespace.h"
+#include "catalog/pg_inherits.h"
 #include "catalog/pg_inherits_fn.h"
 #include "commands/lockcmds.h"
 #include "miscadmin.h"
@@ -113,7 +114,7 @@ LockTableRecurse(Oid reloid, LOCKMODE lockmode, bool nowait)
 	List	   *children;
 	ListCell   *lc;
 
-	children = find_inheritance_children(reloid, NoLock);
+	children = find_inheritance_children(InheritsRelationId, reloid, NoLock);
 
 	foreach(lc, children)
 	{

--- a/src/backend/parser/parse_utilcmd.c
+++ b/src/backend/parser/parse_utilcmd.c
@@ -535,6 +535,9 @@ transformCreateLabelStmt(CreateStmt *stmt, const char *queryString)
 		if (stmt->inhRelations == NULL)
 			stmt->inhRelations = list_make1(
 									makeRangeVar(AG_GRAPH, AG_VERTEX, -1));
+		/* TODO : issue #10
+		 * check parents whether that they are VLABEL or not.
+		 * And set AG_GRAPH to its schema */
 	}
 	else if (nodeTag(stmt) == T_CreateELabelStmt)
 	{
@@ -543,6 +546,9 @@ transformCreateLabelStmt(CreateStmt *stmt, const char *queryString)
 		if (stmt->inhRelations == NULL)
 			stmt->inhRelations = list_make1(
 									makeRangeVar(AG_GRAPH, AG_EDGE, -1));
+		/* TODO : issue #10
+		 * check parents whether that they are ELABEL or not
+		 * And set AG_GRAPH to its schema */
 	}
 	else
 	{

--- a/src/backend/tcop/utility.c
+++ b/src/backend/tcop/utility.c
@@ -1579,7 +1579,7 @@ ExecDropStmt(DropStmt *stmt, bool isTopLevel)
 		case OBJECT_VLABEL:
 		case OBJECT_ELABEL:
 			RemoveLabels(stmt);
-			/* fall through */
+			break;
 
 		case OBJECT_TABLE:
 		case OBJECT_SEQUENCE:

--- a/src/include/catalog/ag_inherits.h
+++ b/src/include/catalog/ag_inherits.h
@@ -1,0 +1,58 @@
+/*-------------------------------------------------------------------------
+ *
+ * ag_inherits.h
+ *	  definition of the system "inherits" relation (ag_inherits)
+ *	  along with the relation's initial contents.
+ *
+ *
+ * Copyright (c) 2016 by Bitnine Global, Inc.
+ *
+ * src/include/catalog/ag_inherits.h
+ *
+ * NOTES
+ *	  the genbki.pl script reads this file and generates .bki
+ *	  information from the DATA() statements.
+ *
+ *-------------------------------------------------------------------------
+ */
+#ifndef AG_INHERITS_H
+#define AG_INHERITS_H
+
+#include "catalog/genbki.h"
+
+/* ----------------
+ *		ag_inherits definition.  cpp turns this into
+ *		typedef struct FormData_ag_inherits
+ * ----------------
+ */
+#define InheritsLabelId 3300
+
+CATALOG(ag_inherits,3300) BKI_WITHOUT_OIDS
+{
+	Oid			inhrelid;
+	Oid			inhparent;
+	int32		inhseqno;
+} FormData_ag_inherits;
+
+/* ----------------
+ *		Form_ag_inherits corresponds to a pointer to a tuple with
+ *		the format of ag_inherits relation.
+ * ----------------
+ */
+typedef FormData_ag_inherits *Form_ag_inherits;
+
+/* ----------------
+ *		compiler constants for ag_inherits
+ * ----------------
+ */
+#define Natts_ag_inherits				3
+#define Anum_ag_inherits_inhrelid		1
+#define Anum_ag_inherits_inhparent		2
+#define Anum_ag_inherits_inhseqno		3
+
+/* ----------------
+ *		ag_inherits has no initial contents
+ * ----------------
+ */
+
+#endif   /* AG_INHERITS_H */

--- a/src/include/catalog/heap.h
+++ b/src/include/catalog/heap.h
@@ -85,6 +85,8 @@ extern void heap_truncate_check_FKs(List *relations, bool tempTables);
 
 extern List *heap_truncate_find_FKs(List *relationIds);
 
+extern void RelationRemoveInheritance(Oid classid, Oid relid);
+
 extern void InsertPgAttributeTuple(Relation pg_attribute_rel,
 					   Form_pg_attribute new_attribute,
 					   CatalogIndexState indstate);
@@ -95,7 +97,7 @@ extern void InsertPgClassTuple(Relation pg_class_desc,
 				   Datum relacl,
 				   Datum reloptions);
 
-extern void InsertAgLabelTuple(Oid relid, const char *relname, char labkind);
+extern void InsertAgLabelTuple(Oid relid, const char *relname, char labkind, List *supers);
 
 extern List *AddRelationNewConstraints(Relation rel,
 						  List *newColDefaults,

--- a/src/include/catalog/indexing.h
+++ b/src/include/catalog/indexing.h
@@ -319,6 +319,9 @@ DECLARE_UNIQUE_INDEX(pg_replication_origin_roname_index, 6002, on pg_replication
 DECLARE_UNIQUE_INDEX(ag_label_oid_index, 3296, on ag_label using btree(oid oid_ops));
 #define LabelOidIndexId 3296
 
+DECLARE_UNIQUE_INDEX(ag_inherits_relid_seqno_index, 3325, on ag_inherits using btree(inhrelid oid_ops, inhseqno int4_ops));
+#define InheritsLabidSeqnoIndexId  3325
+
 /* last step of initialization script: build the indexes declared above */
 BUILD_INDICES
 

--- a/src/include/catalog/pg_inherits_fn.h
+++ b/src/include/catalog/pg_inherits_fn.h
@@ -17,7 +17,7 @@
 #include "nodes/pg_list.h"
 #include "storage/lock.h"
 
-extern List *find_inheritance_children(Oid parentrelId, LOCKMODE lockmode);
+extern List *find_inheritance_children(Oid classId, Oid parentrelId, LOCKMODE lockmode);
 extern List *find_all_inheritors(Oid parentrelId, LOCKMODE lockmode,
 					List **parents);
 extern bool has_subclass(Oid relationId);

--- a/src/include/catalog/unused_oids
+++ b/src/include/catalog/unused_oids
@@ -27,7 +27,7 @@ export FIRSTOBJECTID
 # note: we exclude BKI_BOOTSTRAP relations since they are expected to have
 # matching DATA lines in pg_class.h and pg_type.h
 
-cat pg_*.h toasting.h indexing.h | \
+cat pg_*.h toasting.h indexing.h ag_*.h | \
 egrep -v -e '^CATALOG\(.*BKI_BOOTSTRAP' | \
 sed -n	-e 's/^DATA(insert *OID *= *\([0-9][0-9]*\).*$/\1/p' \
 	-e 's/^CATALOG([^,]*, *\([0-9][0-9]*\).*BKI_ROWTYPE_OID(\([0-9][0-9]*\)).*$/\1,\2/p' \


### PR DESCRIPTION
DROP V/ELABEL CASCADE had a bug.
Wher the child label is dropped, its catalog in ag_label is not removed.
This bug is fixed with this commit.
Also duplcation check is performed with ag_label.