### PR TITLE
feat: Support WHERE in MATCH clause

### DIFF
--- a/src/backend/nodes/copyfuncs.c
+++ b/src/backend/nodes/copyfuncs.c
@@ -4130,6 +4130,7 @@ _copyCypherMatchClause(const CypherMatchClause *from)
 	CypherMatchClause *newnode = makeNode(CypherMatchClause);
 
 	COPY_NODE_FIELD(patterns);
+	COPY_NODE_FIELD(where);
 
 	return newnode;
 }

--- a/src/backend/nodes/equalfuncs.c
+++ b/src/backend/nodes/equalfuncs.c
@@ -2584,6 +2584,7 @@ static bool
 _equalCypherMatchClause(const CypherMatchClause *a, const CypherMatchClause *b)
 {
 	COMPARE_NODE_FIELD(patterns);
+	COMPARE_NODE_FIELD(where);
 
 	return true;
 }

--- a/src/backend/nodes/outfuncs.c
+++ b/src/backend/nodes/outfuncs.c
@@ -2974,6 +2974,7 @@ _outCypherMatchClause(StringInfo str, const CypherMatchClause *node)
 	WRITE_NODE_TYPE("CYPHERMATCHCLAUSE");
 
 	WRITE_NODE_FIELD(patterns);
+	WRITE_NODE_FIELD(where);
 }
 
 static void

--- a/src/backend/parser/gram.y
+++ b/src/backend/parser/gram.y
@@ -14173,10 +14173,11 @@ cypher_clause:
 		;
 
 cypher_match:
-			MATCH cypher_pattern_list
+			MATCH cypher_pattern_list where_clause
 				{
 					CypherMatchClause *n = makeNode(CypherMatchClause);
 					n->patterns = $2;
+					n->where = $3;
 					$$ = (Node *) n;
 				}
 		;


### PR DESCRIPTION
It is impossible to refer to field aliases in the SQL WHERE clause.
Therefore, wrap MATCH clause with an additional SELECT statement which
has the WHERE qualifications so that WHERE can refer to variables
in the result of MATCH clause.