### PR TITLE
feat: Support ORDER BY, SKIP, and LIMIT in RETURN clause

### DIFF
--- a/src/backend/nodes/copyfuncs.c
+++ b/src/backend/nodes/copyfuncs.c
@@ -4141,6 +4141,9 @@ _copyCypherReturnClause(const CypherReturnClause *from)
 	CypherReturnClause *newnode = makeNode(CypherReturnClause);
 
 	COPY_NODE_FIELD(items);
+	COPY_NODE_FIELD(order);
+	COPY_NODE_FIELD(skip);
+	COPY_NODE_FIELD(limit);
 
 	return newnode;
 }

--- a/src/backend/nodes/equalfuncs.c
+++ b/src/backend/nodes/equalfuncs.c
@@ -2594,6 +2594,9 @@ _equalCypherReturnClause(const CypherReturnClause *a,
 						 const CypherReturnClause *b)
 {
 	COMPARE_NODE_FIELD(items);
+	COMPARE_NODE_FIELD(order);
+	COMPARE_NODE_FIELD(skip);
+	COMPARE_NODE_FIELD(limit);
 
 	return true;
 }

--- a/src/backend/nodes/outfuncs.c
+++ b/src/backend/nodes/outfuncs.c
@@ -2983,6 +2983,9 @@ _outCypherReturnClause(StringInfo str, const CypherReturnClause *node)
 	WRITE_NODE_TYPE("CYPHERRETURNCLAUSE");
 
 	WRITE_NODE_FIELD(items);
+	WRITE_NODE_FIELD(order);
+	WRITE_NODE_FIELD(skip);
+	WRITE_NODE_FIELD(limit);
 }
 
 static void

--- a/src/include/nodes/parsenodes.h
+++ b/src/include/nodes/parsenodes.h
@@ -3104,6 +3104,9 @@ typedef struct CypherReturnClause
 {
 	NodeTag		type;
 	List	   *items;		/* list of return items (ResTarget) */
+	List	   *order;		/* a list of SortBy's */
+	Node	   *skip;		/* number of result tuples to skip */
+	Node	   *limit;		/* number of result tuples to return */
 } CypherReturnClause;
 
 typedef struct CypherPattern


### PR DESCRIPTION
Wrap RETURN clause with an additional SELECT statement which has the
ORDER BY, SKIP, and LIMIT options so that such options can refer to
aliased variables.