### PR TITLE
fix: Generate GROUP BY if aggreates exist

### DIFF
--- a/src/backend/parser/parse_clause.c
+++ b/src/backend/parser/parse_clause.c
@@ -3432,6 +3432,9 @@ generateGroupClause(ParseState *pstate, List **targetlist, List *sortClause)
 	gen_group_exprs_context ctx;
 	ListCell   *gl;
 
+	if (!pstate->p_hasAggs)
+		return NIL;
+
 	ctx.group_exprs = NIL;
 	ctx.sublevels_up = 0;
 	gen_group_exprs_walker((Node *) *targetlist, &ctx);

--- a/src/backend/parser/parse_graph.c
+++ b/src/backend/parser/parse_graph.c
@@ -342,7 +342,8 @@ makePatternCtx(RangeTblEntry *rte)
 		Value	   *colname;
 		Oid			vartype;
 
-		Assert(!(te == NULL || te->resjunk));
+		if (te->resjunk)
+			continue;
 
 		colname = makeString(pstrdup(te->resname));
 


### PR DESCRIPTION
And remove `!resjunk` assertion of piped results because they might
have `resjunk` targets due to ORDER or aggreate functions.