### PR TITLE
fix: Add start/end to `edge` out format

### DIFF
--- a/src/backend/parser/parse_utilcmd.c
+++ b/src/backend/parser/parse_utilcmd.c
@@ -3155,6 +3155,7 @@ makeEdgeElements(void)
 	prop_map->colname = AG_ELEM_PROP_MAP;
 	prop_map->typeName = makeTypeName("jsonb");
 	prop_map->is_local = true;
+	prop_map->constraints = constr;
 	prop_map->location = -1;
 
 	return list_make4(id, start, end, prop_map);

--- a/src/backend/utils/adt/graph.c
+++ b/src/backend/utils/adt/graph.c
@@ -183,8 +183,12 @@ edge_out(PG_FUNCTION_ARGS)
 	my_extra = cache_label(fcinfo->flinfo, id.oid);
 
 	initStringInfo(&si);
-	appendStringInfo(&si, ":%s[" GRAPHID_FMTSTR "]",
+	appendStringInfo(&si, ":%s[" GRAPHID_FMTSTR "][",
 					 NameStr(my_extra->label), id.oid, id.lid);
+	graphid_out_si(&si, values[Anum_edge_start - 1]);
+	appendStringInfoChar(&si, ',');
+	graphid_out_si(&si, values[Anum_edge_end - 1]);
+	appendStringInfoChar(&si, ']');
 	JsonbToCString(&si, &prop_map->root, VARSIZE(prop_map));
 
 	PG_RETURN_CSTRING(si.data);

--- a/src/include/catalog/pg_proc.h
+++ b/src/include/catalog/pg_proc.h
@@ -5326,6 +5326,10 @@ DATA(insert OID = 6014 ( pg_show_replication_origin_status PGNSP PGUID 12 1 100 
 DESCR("get progress for all replication origins");
 
 /* graph */
+DATA(insert OID = 7003 ( graphid_in		PGNSP PGUID 12 1 0 0 0 f f f f t f i 1 0 7002 "2275" _null_ _null_ _null_ _null_ _null_ graphid_in _null_ _null_ _null_ ));
+DESCR("I/O");
+DATA(insert OID = 7004 ( graphid_out	PGNSP PGUID 12 1 0 0 0 f f f f t f i 1 0 2275 "7002" _null_ _null_ _null_ _null_ _null_ graphid_out _null_ _null_ _null_ ));
+DESCR("I/O");
 DATA(insert OID = 7014 ( vertex_out		PGNSP PGUID 12 1 0 0 0 f f f f t f i 1 0 2275 "7012" _null_ _null_ _null_ _null_ _null_ vertex_out _null_ _null_ _null_ ));
 DESCR("I/O");
 DATA(insert OID = 7024 ( edge_out		PGNSP PGUID 12 1 0 0 0 f f f f t f i 1 0 2275 "7022" _null_ _null_ _null_ _null_ _null_ edge_out _null_ _null_ _null_ ));

--- a/src/include/catalog/pg_type.h
+++ b/src/include/catalog/pg_type.h
@@ -653,7 +653,7 @@ DATA(insert OID = 3927 ( _int8range		PGNSP PGUID  -1 f b A f t \054 0 3926 0 arr
 
 /* types for graphs */
 DATA(insert OID = 7001 ( _graphid	PGNSP PGUID -1 f b A f t \054 0 7002 0 array_in array_out array_recv array_send - - array_typanalyze d x f 0 -1 0 0 _null_ _null_ _null_ ));
-DATA(insert OID = 7002 ( graphid	PGNSP PGUID -1 f c C f t \054 7000 0 7001 record_in record_out record_recv record_send - - - d x f 0 -1 0 0 _null_ _null_ _null_ ));
+DATA(insert OID = 7002 ( graphid	PGNSP PGUID -1 f c C f t \054 7000 0 7001 graphid_in graphid_out record_recv record_send - - - d x f 0 -1 0 0 _null_ _null_ _null_ ));
 DESCR("(oid, lid), unique ID of vertex/edge");
 #define GRAPHIDOID		7002
 DATA(insert OID = 7011 ( _vertex	PGNSP PGUID -1 f b A f t \054 0 7012 0 array_in array_out array_recv array_send - - array_typanalyze d x f 0 -1 0 0 _null_ _null_ _null_ ));

--- a/src/include/utils/graph.h
+++ b/src/include/utils/graph.h
@@ -20,6 +20,8 @@ typedef struct Graphid
 	int64		lid;
 } Graphid;
 
+extern Datum graphid_in(PG_FUNCTION_ARGS);
+extern Datum graphid_out(PG_FUNCTION_ARGS);
 extern Datum vertex_out(PG_FUNCTION_ARGS);
 extern Datum edge_out(PG_FUNCTION_ARGS);
 extern Datum graphpath_out(PG_FUNCTION_ARGS);

--- a/src/test/regress/expected/type_sanity.out
+++ b/src/test/regress/expected/type_sanity.out
@@ -168,13 +168,14 @@ SELECT DISTINCT typtype, typinput
 FROM pg_type AS p1
 WHERE p1.typtype not in ('b', 'p')
 ORDER BY 1;
- typtype | typinput  
----------+-----------
+ typtype |  typinput  
+---------+------------
+ c       | graphid_in
  c       | record_in
  d       | domain_in
  e       | enum_in
  r       | range_in
-(4 rows)
+(5 rows)
 
 -- Check for bogus typoutput routines
 -- As of 8.0, this check finds refcursor, which is borrowing
@@ -215,13 +216,14 @@ WHERE p1.typtype not in ('b', 'd', 'p')
 ORDER BY 1;
  typtype |   typoutput   
 ---------+---------------
- c       | record_out
+ c       | graphid_out
  c       | vertex_out
  c       | graphpath_out
+ c       | record_out
  c       | edge_out
  e       | enum_out
  r       | range_out
-(6 rows)
+(7 rows)
 
 -- Domains should have same typoutput as their base types
 SELECT p1.oid, p1.typname, p2.oid, p2.typname
@@ -277,9 +279,10 @@ SELECT p1.oid, p1.typname, p2.oid, p2.proname, p3.oid, p3.proname
 FROM pg_type AS p1, pg_proc AS p2, pg_proc AS p3
 WHERE p1.typinput = p2.oid AND p1.typreceive = p3.oid AND
     p2.pronargs != p3.pronargs;
- oid | typname | oid | proname | oid | proname 
------+---------+-----+---------+-----+---------
-(0 rows)
+ oid  | typname | oid  |  proname   | oid  |   proname   
+------+---------+------+------------+------+-------------
+ 7002 | graphid | 7003 | graphid_in | 2402 | record_recv
+(1 row)
 
 -- typreceive routines should not be volatile
 SELECT p1.oid, p1.typname, p2.oid, p2.proname


### PR DESCRIPTION
Use `oid.lid` format as `graphid` in/out strings