### PR TITLE
feat: Implement JSON object expression

### DIFF
--- a/src/backend/nodes/copyfuncs.c
+++ b/src/backend/nodes/copyfuncs.c
@@ -4128,6 +4128,27 @@ _copyCypherStmt(const CypherStmt *from)
 	return newnode;
 }
 
+static JsonObject *
+_copyJsonObject(const JsonObject *from)
+{
+	JsonObject *newnode = makeNode(JsonObject);
+
+	COPY_NODE_FIELD(keyvals);
+
+	return newnode;
+}
+
+static JsonKeyVal *
+_copyJsonKeyVal(const JsonKeyVal *from)
+{
+	JsonKeyVal *newnode = makeNode(JsonKeyVal);
+
+	COPY_NODE_FIELD(key);
+	COPY_NODE_FIELD(val);
+
+	return newnode;
+}
+
 static CypherClause *
 _copyCypherClause(const CypherClause *from)
 {
@@ -4205,7 +4226,7 @@ _copyCypherNode(const CypherNode *from)
 
 	COPY_NODE_FIELD(variable);
 	COPY_NODE_FIELD(label);
-	COPY_STRING_FIELD(prop_map);
+	COPY_NODE_FIELD(prop_map);
 
 	return newnode;
 }
@@ -4219,7 +4240,7 @@ _copyCypherRel(const CypherRel *from)
 	COPY_NODE_FIELD(variable);
 	COPY_NODE_FIELD(types);
 	COPY_NODE_FIELD(varlen);
-	COPY_STRING_FIELD(prop_map);
+	COPY_NODE_FIELD(prop_map);
 
 	return newnode;
 }
@@ -4253,7 +4274,8 @@ _copyGraphVertex(const GraphVertex *from)
 
 	COPY_STRING_FIELD(variable);
 	COPY_STRING_FIELD(label);
-	COPY_STRING_FIELD(prop_map);
+	COPY_NODE_FIELD(prop_map);
+	COPY_NODE_FIELD(es_prop_map);
 	COPY_SCALAR_FIELD(create);
 
 	return newnode;
@@ -4267,7 +4289,8 @@ _copyGraphEdge(const GraphEdge *from)
 	COPY_SCALAR_FIELD(direction);
 	COPY_STRING_FIELD(variable);
 	COPY_STRING_FIELD(label);
-	COPY_STRING_FIELD(prop_map);
+	COPY_NODE_FIELD(prop_map);
+	COPY_NODE_FIELD(es_prop_map);
 
 	return newnode;
 }
@@ -5133,6 +5156,12 @@ copyObject(const void *from)
 			break;
 		case T_RoleSpec:
 			retval = _copyRoleSpec(from);
+			break;
+		case T_JsonObject:
+			retval = _copyJsonObject(from);
+			break;
+		case T_JsonKeyVal:
+			retval = _copyJsonKeyVal(from);
 			break;
 		case T_CypherClause:
 			retval = _copyCypherClause(from);

--- a/src/backend/nodes/copyfuncs.c
+++ b/src/backend/nodes/copyfuncs.c
@@ -23,6 +23,7 @@
 #include "postgres.h"
 
 #include "miscadmin.h"
+#include "nodes/graphnodes.h"
 #include "nodes/plannodes.h"
 #include "nodes/relation.h"
 #include "utils/datum.h"
@@ -4205,7 +4206,6 @@ _copyCypherNode(const CypherNode *from)
 	COPY_NODE_FIELD(variable);
 	COPY_NODE_FIELD(label);
 	COPY_STRING_FIELD(prop_map);
-	COPY_SCALAR_FIELD(create);
 
 	return newnode;
 }
@@ -4231,6 +4231,43 @@ _copyCypherName(const CypherName *from)
 
 	COPY_STRING_FIELD(name);
 	COPY_LOCATION_FIELD(location);
+
+	return newnode;
+}
+
+static GraphPath *
+_copyGraphPath(const GraphPath *from)
+{
+	GraphPath *newnode = makeNode(GraphPath);
+
+	COPY_STRING_FIELD(variable);
+	COPY_NODE_FIELD(chain);
+
+	return newnode;
+}
+
+static GraphVertex *
+_copyGraphVertex(const GraphVertex *from)
+{
+	GraphVertex *newnode = makeNode(GraphVertex);
+
+	COPY_STRING_FIELD(variable);
+	COPY_STRING_FIELD(label);
+	COPY_STRING_FIELD(prop_map);
+	COPY_SCALAR_FIELD(create);
+
+	return newnode;
+}
+
+static GraphEdge *
+_copyGraphEdge(const GraphEdge *from)
+{
+	GraphEdge *newnode = makeNode(GraphEdge);
+
+	COPY_SCALAR_FIELD(direction);
+	COPY_STRING_FIELD(variable);
+	COPY_STRING_FIELD(label);
+	COPY_STRING_FIELD(prop_map);
 
 	return newnode;
 }
@@ -5123,6 +5160,19 @@ copyObject(const void *from)
 			break;
 		case T_CypherName:
 			retval = _copyCypherName(from);
+			break;
+
+			/*
+			 * GRAPH NODES
+			 */
+		case T_GraphPath:
+			retval = _copyGraphPath(from);
+			break;
+		case T_GraphVertex:
+			retval = _copyGraphVertex(from);
+			break;
+		case T_GraphEdge:
+			retval = _copyGraphEdge(from);
 			break;
 
 		default:

--- a/src/backend/nodes/equalfuncs.c
+++ b/src/backend/nodes/equalfuncs.c
@@ -2571,6 +2571,23 @@ _equalRoleSpec(const RoleSpec *a, const RoleSpec *b)
 }
 
 static bool
+_equalJsonObject(const JsonObject *a, const JsonObject *b)
+{
+	COMPARE_NODE_FIELD(keyvals);
+
+	return true;
+}
+
+static bool
+_equalJsonKeyVal(const JsonKeyVal *a, const JsonKeyVal *b)
+{
+	COMPARE_NODE_FIELD(key);
+	COMPARE_NODE_FIELD(val);
+
+	return true;
+}
+
+static bool
 _equalCreateLabelStmt(const CreateLabelStmt *a, const CreateLabelStmt *b)
 {
 	COMPARE_NODE_FIELD(relation);
@@ -2653,7 +2670,7 @@ _equalCypherNode(const CypherNode *a, const CypherNode *b)
 {
 	COMPARE_NODE_FIELD(variable);
 	COMPARE_NODE_FIELD(label);
-	COMPARE_STRING_FIELD(prop_map);
+	COMPARE_NODE_FIELD(prop_map);
 
 	return true;
 }
@@ -2665,7 +2682,7 @@ _equalCypherRel(const CypherRel *a, const CypherRel *b)
 	COMPARE_NODE_FIELD(variable);
 	COMPARE_NODE_FIELD(types);
 	COMPARE_NODE_FIELD(varlen);
-	COMPARE_STRING_FIELD(prop_map);
+	COMPARE_NODE_FIELD(prop_map);
 
 	return true;
 }
@@ -2692,7 +2709,8 @@ _equalGraphVertex(const GraphVertex *a, const GraphVertex *b)
 {
 	COMPARE_STRING_FIELD(variable);
 	COMPARE_STRING_FIELD(label);
-	COMPARE_STRING_FIELD(prop_map);
+	COMPARE_NODE_FIELD(prop_map);
+	COMPARE_NODE_FIELD(es_prop_map);
 	COMPARE_SCALAR_FIELD(create);
 
 	return true;
@@ -2704,7 +2722,8 @@ _equalGraphEdge(const GraphEdge *a, const GraphEdge *b)
 	COMPARE_SCALAR_FIELD(direction);
 	COMPARE_STRING_FIELD(variable);
 	COMPARE_STRING_FIELD(label);
-	COMPARE_STRING_FIELD(prop_map);
+	COMPARE_NODE_FIELD(prop_map);
+	COMPARE_NODE_FIELD(es_prop_map);
 
 	return true;
 }
@@ -3442,6 +3461,13 @@ equal(const void *a, const void *b)
 			break;
 		case T_RoleSpec:
 			retval = _equalRoleSpec(a, b);
+			break;
+
+		case T_JsonObject:
+			retval = _equalJsonObject(a, b);
+			break;
+		case T_JsonKeyVal:
+			retval = _equalJsonKeyVal(a, b);
 			break;
 
 		case T_CreateLabelStmt:

--- a/src/backend/nodes/equalfuncs.c
+++ b/src/backend/nodes/equalfuncs.c
@@ -29,6 +29,7 @@
 
 #include "postgres.h"
 
+#include "nodes/graphnodes.h"
 #include "nodes/relation.h"
 #include "utils/datum.h"
 
@@ -2620,15 +2621,6 @@ _equalCypherProjection(const CypherProjection *a, const CypherProjection *b)
 }
 
 static bool
-_equalCypherPath(const CypherPath *a, const CypherPath *b)
-{
-	COMPARE_NODE_FIELD(variable);
-	COMPARE_NODE_FIELD(chain);
-
-	return true;
-}
-
-static bool
 _equalCypherCreateClause(const CypherCreateClause *a,
 						 const CypherCreateClause *b)
 {
@@ -2648,12 +2640,20 @@ _equalCypherDeleteClause(const CypherDeleteClause *a,
 }
 
 static bool
+_equalCypherPath(const CypherPath *a, const CypherPath *b)
+{
+	COMPARE_NODE_FIELD(variable);
+	COMPARE_NODE_FIELD(chain);
+
+	return true;
+}
+
+static bool
 _equalCypherNode(const CypherNode *a, const CypherNode *b)
 {
 	COMPARE_NODE_FIELD(variable);
 	COMPARE_NODE_FIELD(label);
 	COMPARE_STRING_FIELD(prop_map);
-	COMPARE_SCALAR_FIELD(create);
 
 	return true;
 }
@@ -2674,6 +2674,37 @@ static bool
 _equalCypherName(const CypherName *a, const CypherName *b)
 {
 	COMPARE_STRING_FIELD(name);
+
+	return true;
+}
+
+static bool
+_equalGraphPath(const GraphPath *a, const GraphPath *b)
+{
+	COMPARE_STRING_FIELD(variable);
+	COMPARE_NODE_FIELD(chain);
+
+	return true;
+}
+
+static bool
+_equalGraphVertex(const GraphVertex *a, const GraphVertex *b)
+{
+	COMPARE_STRING_FIELD(variable);
+	COMPARE_STRING_FIELD(label);
+	COMPARE_STRING_FIELD(prop_map);
+	COMPARE_SCALAR_FIELD(create);
+
+	return true;
+}
+
+static bool
+_equalGraphEdge(const GraphEdge *a, const GraphEdge *b)
+{
+	COMPARE_SCALAR_FIELD(direction);
+	COMPARE_STRING_FIELD(variable);
+	COMPARE_STRING_FIELD(label);
+	COMPARE_STRING_FIELD(prop_map);
 
 	return true;
 }
@@ -3446,6 +3477,19 @@ equal(const void *a, const void *b)
 			break;
 		case T_CypherName:
 			retval = _equalCypherName(a, b);
+			break;
+
+			/*
+			 * GRAPH NODES
+			 */
+		case T_GraphPath:
+			retval = _equalGraphPath(a, b);
+			break;
+		case T_GraphVertex:
+			retval = _equalGraphVertex(a, b);
+			break;
+		case T_GraphEdge:
+			retval = _equalGraphEdge(a, b);
 			break;
 
 		default:

--- a/src/backend/nodes/outfuncs.c
+++ b/src/backend/nodes/outfuncs.c
@@ -24,6 +24,7 @@
 #include <ctype.h>
 
 #include "lib/stringinfo.h"
+#include "nodes/graphnodes.h"
 #include "nodes/plannodes.h"
 #include "nodes/relation.h"
 #include "utils/datum.h"
@@ -3040,7 +3041,6 @@ _outCypherNode(StringInfo str, const CypherNode *node)
 	WRITE_NODE_FIELD(variable);
 	WRITE_NODE_FIELD(label);
 	WRITE_STRING_FIELD(prop_map);
-	WRITE_BOOL_FIELD(create);
 }
 
 static void
@@ -3062,6 +3062,37 @@ _outCypherName(StringInfo str, const CypherName *node)
 
 	WRITE_STRING_FIELD(name);
 	WRITE_LOCATION_FIELD(location);
+}
+
+static void
+_outGraphPath(StringInfo str, const GraphPath *node)
+{
+	WRITE_NODE_TYPE("GRAPHPATH");
+
+	WRITE_STRING_FIELD(variable);
+	WRITE_NODE_FIELD(chain);
+}
+
+static void
+_outGraphVertex(StringInfo str, const GraphVertex *node)
+{
+	WRITE_NODE_TYPE("GRAPHVERTEX");
+
+	WRITE_STRING_FIELD(variable);
+	WRITE_STRING_FIELD(label);
+	WRITE_STRING_FIELD(prop_map);
+	WRITE_BOOL_FIELD(create);
+}
+
+static void
+_outGraphEdge(StringInfo str, const GraphEdge *node)
+{
+	WRITE_NODE_TYPE("GRAPHEDGE");
+
+	WRITE_INT_FIELD(direction);
+	WRITE_STRING_FIELD(variable);
+	WRITE_STRING_FIELD(label);
+	WRITE_STRING_FIELD(prop_map);
 }
 
 /*
@@ -3621,6 +3652,16 @@ _outNode(StringInfo str, const void *obj)
 				break;
 			case T_CypherName:
 				_outCypherName(str, obj);
+				break;
+
+			case T_GraphPath:
+				_outGraphPath(str, obj);
+				break;
+			case T_GraphVertex:
+				_outGraphVertex(str, obj);
+				break;
+			case T_GraphEdge:
+				_outGraphEdge(str, obj);
 				break;
 
 			default:

--- a/src/backend/nodes/outfuncs.c
+++ b/src/backend/nodes/outfuncs.c
@@ -2958,6 +2958,23 @@ _outConstraint(StringInfo str, const Constraint *node)
 }
 
 static void
+_outJsonObject(StringInfo str, const JsonObject *node)
+{
+	WRITE_NODE_TYPE("JSONOBJECT");
+
+	WRITE_NODE_FIELD(keyvals);
+}
+
+static void
+_outJsonKeyVal(StringInfo str, const JsonKeyVal *node)
+{
+	WRITE_NODE_TYPE("JSONKEYVAL");
+
+	WRITE_NODE_FIELD(key);
+	WRITE_NODE_FIELD(val);
+}
+
+static void
 _outCreateLabelStmt(StringInfo str, const CreateLabelStmt *node)
 {
 	WRITE_NODE_TYPE("CREATELABELSTMT");
@@ -3040,7 +3057,7 @@ _outCypherNode(StringInfo str, const CypherNode *node)
 
 	WRITE_NODE_FIELD(variable);
 	WRITE_NODE_FIELD(label);
-	WRITE_STRING_FIELD(prop_map);
+	WRITE_NODE_FIELD(prop_map);
 }
 
 static void
@@ -3052,7 +3069,7 @@ _outCypherRel(StringInfo str, const CypherRel *node)
 	WRITE_NODE_FIELD(variable);
 	WRITE_NODE_FIELD(types);
 	WRITE_NODE_FIELD(varlen);
-	WRITE_STRING_FIELD(prop_map);
+	WRITE_NODE_FIELD(prop_map);
 }
 
 static void
@@ -3080,7 +3097,8 @@ _outGraphVertex(StringInfo str, const GraphVertex *node)
 
 	WRITE_STRING_FIELD(variable);
 	WRITE_STRING_FIELD(label);
-	WRITE_STRING_FIELD(prop_map);
+	WRITE_NODE_FIELD(prop_map);
+	WRITE_NODE_FIELD(es_prop_map);
 	WRITE_BOOL_FIELD(create);
 }
 
@@ -3092,7 +3110,8 @@ _outGraphEdge(StringInfo str, const GraphEdge *node)
 	WRITE_INT_FIELD(direction);
 	WRITE_STRING_FIELD(variable);
 	WRITE_STRING_FIELD(label);
-	WRITE_STRING_FIELD(prop_map);
+	WRITE_NODE_FIELD(prop_map);
+	WRITE_NODE_FIELD(es_prop_map);
 }
 
 /*
@@ -3617,6 +3636,13 @@ _outNode(StringInfo str, const void *obj)
 				break;
 			case T_XmlSerialize:
 				_outXmlSerialize(str, obj);
+				break;
+
+			case T_JsonObject:
+				_outJsonObject(str, obj);
+				break;
+			case T_JsonKeyVal:
+				_outJsonKeyVal(str, obj);
 				break;
 
 			case T_CreateLabelStmt:

--- a/src/backend/nodes/readfuncs.c
+++ b/src/backend/nodes/readfuncs.c
@@ -28,6 +28,7 @@
 
 #include <math.h>
 
+#include "nodes/graphnodes.h"
 #include "nodes/parsenodes.h"
 #include "nodes/readfuncs.h"
 
@@ -1372,6 +1373,45 @@ _readTableSampleClause(void)
 	READ_DONE();
 }
 
+static GraphPath *
+_readGraphPath(void)
+{
+	READ_LOCALS(GraphPath);
+
+	READ_STRING_FIELD(variable);
+	READ_NODE_FIELD(chain);
+
+	READ_DONE();
+}
+
+static GraphVertex *
+_readGraphVertex(void)
+{
+	READ_LOCALS(GraphVertex);
+
+	READ_STRING_FIELD(variable);
+	READ_STRING_FIELD(label);
+	READ_NODE_FIELD(prop_map);
+	READ_NODE_FIELD(es_prop_map);
+	READ_BOOL_FIELD(create);
+
+	READ_DONE();
+}
+
+static GraphEdge *
+_readGraphEdge(void)
+{
+	READ_LOCALS(GraphEdge);
+
+	READ_INT_FIELD(direction);
+	READ_STRING_FIELD(variable);
+	READ_STRING_FIELD(label);
+	READ_NODE_FIELD(prop_map);
+	READ_NODE_FIELD(es_prop_map);
+
+	READ_DONE();
+}
+
 
 /*
  * parseNodeString
@@ -1511,6 +1551,12 @@ parseNodeString(void)
 		return_value = _readNotifyStmt();
 	else if (MATCH("DECLARECURSOR", 13))
 		return_value = _readDeclareCursorStmt();
+	else if (MATCH("GRAPHPATH", 9))
+		return_value = _readGraphPath();
+	else if (MATCH("GRAPHVERTEX", 11))
+		return_value = _readGraphVertex();
+	else if (MATCH("GRAPHEDGE", 9))
+		return_value = _readGraphEdge();
 	else
 	{
 		elog(ERROR, "badly formatted node string \"%.32s\"...", token);

--- a/src/backend/parser/gram.y
+++ b/src/backend/parser/gram.y
@@ -14290,7 +14290,6 @@ cypher_node:
 					n->variable = $2;
 					n->label = $3;
 					n->prop_map = $4;
-					n->create = false;
 					$$ = (Node *) n;
 				}
 		;

--- a/src/include/nodes/execnodes.h
+++ b/src/include/nodes/execnodes.h
@@ -2052,6 +2052,8 @@ typedef struct ModifyGraphState
 	PlanState	ps;
 	bool		done;
 	PlanState  *subplan;
+	List	   *pattern;		/* graph pattern (list of paths) for CREATE
+								   with `es_prop_map` */
 	List	   *exprs;			/* expression state list for DELETE */
 } ModifyGraphState;
 

--- a/src/include/nodes/graphnodes.h
+++ b/src/include/nodes/graphnodes.h
@@ -10,14 +10,13 @@
 #ifndef GRAPHNODES_H
 #define GRAPHNODES_H
 
-#include "c.h"
-#include "nodes/pg_list.h"
+#include "nodes/execnodes.h"
 
 typedef struct GraphPath
 {
 	NodeTag		type;
 	char	   *variable;
-	List	   *chain;		/* vertex, edge, vertex, ... */
+	List	   *chain;			/* vertex, edge, vertex, ... */
 } GraphPath;
 
 typedef struct GraphVertex
@@ -25,8 +24,9 @@ typedef struct GraphVertex
 	NodeTag		type;
 	char	   *variable;
 	char	   *label;
-	char	   *prop_map;	/* JSON object string */
-	bool		create;		/* whether this vertex will be created or not */
+	Node	   *prop_map;		/* expression of type jsonb */
+	ExprState  *es_prop_map;	/* expression state of `prop_map` */
+	bool		create;			/* whether this vertex will be created or not */
 } GraphVertex;
 
 #define GRAPH_EDGE_DIR_NONE		0
@@ -39,7 +39,8 @@ typedef struct GraphEdge
 	uint32		direction;	/* bitmask of directions (see above) */
 	char	   *variable;
 	char	   *label;
-	char	   *prop_map;	/* JSON object string */
+	Node	   *prop_map;		/* expression of type jsonb */
+	ExprState  *es_prop_map;	/* expression state of `prop_map` */
 } GraphEdge;
 
 #endif	/* GRAPHNODES_H */

--- a/src/include/nodes/graphnodes.h
+++ b/src/include/nodes/graphnodes.h
@@ -1,0 +1,45 @@
+/*
+ * graph.h
+ *	  definitions for graph nodes
+ *
+ * Copyright (c) 2016 by Bitnine Global, Inc.
+ *
+ * src/include/nodes/graphnodes.h
+ */
+
+#ifndef GRAPHNODES_H
+#define GRAPHNODES_H
+
+#include "c.h"
+#include "nodes/pg_list.h"
+
+typedef struct GraphPath
+{
+	NodeTag		type;
+	char	   *variable;
+	List	   *chain;		/* vertex, edge, vertex, ... */
+} GraphPath;
+
+typedef struct GraphVertex
+{
+	NodeTag		type;
+	char	   *variable;
+	char	   *label;
+	char	   *prop_map;	/* JSON object string */
+	bool		create;		/* whether this vertex will be created or not */
+} GraphVertex;
+
+#define GRAPH_EDGE_DIR_NONE		0
+#define GRAPH_EDGE_DIR_LEFT		(1 << 0)
+#define GRAPH_EDGE_DIR_RIGHT	(1 << 1)
+
+typedef struct GraphEdge
+{
+	NodeTag		type;
+	uint32		direction;	/* bitmask of directions (see above) */
+	char	   *variable;
+	char	   *label;
+	char	   *prop_map;	/* JSON object string */
+} GraphEdge;
+
+#endif	/* GRAPHNODES_H */

--- a/src/include/nodes/nodes.h
+++ b/src/include/nodes/nodes.h
@@ -463,7 +463,14 @@ typedef enum NodeTag
 	T_TIDBitmap,				/* in nodes/tidbitmap.h */
 	T_InlineCodeBlock,			/* in nodes/parsenodes.h */
 	T_FdwRoutine,				/* in foreign/fdwapi.h */
-	T_TsmRoutine				/* in access/tsmapi.h */
+	T_TsmRoutine,				/* in access/tsmapi.h */
+
+	/*
+	 * TAGS FOR GRAPH NODES (graphnodes.h)
+	 */
+	T_GraphPath = 1050,
+	T_GraphVertex,
+	T_GraphEdge
 } NodeTag;
 
 /*

--- a/src/include/nodes/nodes.h
+++ b/src/include/nodes/nodes.h
@@ -428,6 +428,8 @@ typedef enum NodeTag
 	T_OnConflictClause,
 	T_CommonTableExpr,
 	T_RoleSpec,
+	T_JsonObject,
+	T_JsonKeyVal,
 	T_CypherClause,
 	T_CypherMatchClause,
 	T_CypherProjection,

--- a/src/include/nodes/parsenodes.h
+++ b/src/include/nodes/parsenodes.h
@@ -3167,7 +3167,6 @@ typedef struct CypherNode
 	Node	   *variable;	/* CypherName */
 	Node	   *label;		/* CypherName */
 	char	   *prop_map;	/* JSON object string */
-	bool		create;		/* this node will be created */
 } CypherNode;
 
 #define CYPHER_REL_DIR_NONE		0

--- a/src/include/nodes/parsenodes.h
+++ b/src/include/nodes/parsenodes.h
@@ -3065,6 +3065,24 @@ typedef struct AlterTSConfigurationStmt
 
 
 /****************************************************************************
+ * JSON object expression
+ ****************************************************************************/
+
+typedef struct JsonObject
+{
+	NodeTag		type;
+	List	   *keyvals;
+} JsonObject;
+
+typedef struct JsonKeyVal
+{
+	NodeTag		type;
+	Node	   *key;
+	Node	   *val;
+} JsonKeyVal;
+
+
+/****************************************************************************
  * Agens Graph related node structures
  ****************************************************************************/
 
@@ -3166,7 +3184,7 @@ typedef struct CypherNode
 	NodeTag		type;
 	Node	   *variable;	/* CypherName */
 	Node	   *label;		/* CypherName */
-	char	   *prop_map;	/* JSON object string */
+	Node	   *prop_map;	/* JSON object expression or string constant */
 } CypherNode;
 
 #define CYPHER_REL_DIR_NONE		0
@@ -3180,7 +3198,7 @@ typedef struct CypherRel
 	Node	   *variable;	/* CypherName */
 	List	   *types;		/* ORed types */
 	Node	   *varlen;		/* variable length relationships (A_Indices) */
-	char	   *prop_map;	/* JSON object string */
+	Node	   *prop_map;	/* JSON object expression or string constant */
 } CypherRel;
 
 typedef struct CypherName

--- a/src/interfaces/ecpg/preproc/check_rules.pl
+++ b/src/interfaces/ecpg/preproc/check_rules.pl
@@ -71,8 +71,8 @@ while (<GRAM>)
 	next if ($_ eq '');
 
 	# Make sure any braces are split
-	s/{/ { /g;
-	s/}/ } /g;
+	s/('\{'|\{)/ $1 /g;
+	s/('\}'|\})/ $1 /g;
 
 	# Any comments are split
 	s|\/\*| /* |g;

--- a/src/interfaces/ecpg/preproc/parse.pl
+++ b/src/interfaces/ecpg/preproc/parse.pl
@@ -160,8 +160,8 @@ sub main
 		my $prec = 0;
 
 		# Make sure any braces are split
-		s/{/ { /g;
-		s/}/ } /g;
+		s/('\{'|\{)/ $1 /g;
+		s/('\}'|\})/ $1 /g;
 
 		# Any comments are split
 		s|\/\*| /* |g;

--- a/src/test/regress/expected/cypher_dml.out
+++ b/src/test/regress/expected/cypher_dml.out
@@ -443,9 +443,13 @@ RETURN id(a) = start(c) AND "end"(c) = id(b) AS atob,
 
 -- wrong cases (duplicated variable)
 CREATE (a), (a);
-ERROR:  variable "a" already exists
+ERROR:  there must be at least one relationship
+LINE 1: CREATE (a), (a);
+                     ^
 CREATE (a:regvlabel1), (b:regvlabel2), (a:regvlabel);
 ERROR:  variable "a" already exists
+LINE 1: CREATE (a:regvlabel1), (b:regvlabel2), (a:regvlabel);
+                                                ^
 -- wrong cases (label)
 CREATE (a:regvlabel1:regvlabel2);
 ERROR:  syntax error at or near ":"
@@ -455,9 +459,9 @@ CREATE (:regvlabel1)-['{"reltype": "empty"}']->(:regvlabel2);
 ERROR:  a single relationship type must be specified for CREATE
 -- wrong cases (bi-directional relationship)
 CREATE (:regvlabel1 '{"name": "insert v1-3"}')-[:regelabel1]-(:regvlabel2 '{"name": "insert v2-3"}');
-ERROR:  only directed relationships are supported in CREATE
+ERROR:  only directed relationships are allowed in CREATE
 CREATE (:regvlabel1 '{"name": "insert v1-4"}')<-[:regelabel1]->(:regvlabel2 '{"name": "insert v2-4"}');
-ERROR:  only directed relationships are supported in CREATE
+ERROR:  only directed relationships are allowed in CREATE
 -- multiple CREATE's
 MATCH (a:regvlabel1), (b:regvlabel2)
 CREATE p=(a)-[:regelabel1 '{"name": "edge1"}']->(b)

--- a/src/test/regress/expected/cypher_dml.out
+++ b/src/test/regress/expected/cypher_dml.out
@@ -22,20 +22,20 @@ CREATE elabel regelabel1;
 NOTICE:  merging column "id" with inherited definition
 CREATE elabel regelabel2;
 NOTICE:  merging column "id" with inherited definition
-CREATE (v1:regvlabel1 '{"name": "regv1-1", "id": 1}'),
-	   (v2:regvlabel1 '{"name": "regv1-2", "id": 2}'),
-	   (v3:regvlabel1 '{"name": "regv1-3", "id": 3}'),
-	   (v4:regvlabel2 '{"name": "regv2-1", "id": 4}'),
-	   (v5:regvlabel2 '{"name": "regv2-2", "id": 5}'),
-	   (v6:regvlabel2 '{"name": "regv2-3", "id": 6}'),
-	   (v7:regvlabel2 '{"name": "regv2-4", "id": 7}'),
-	   (v8:regvlabel2 '{"name": "regv2-5", "id": 8}'),
-	   (v1)-[:regelabel1 '{"name": "rege1-1", "id": 1}']->(v4),
-	   (v2)-[:regelabel1 '{"name": "rege1-2", "id": 2}']->(v5),
-	   (v3)-[:regelabel1 '{"name": "rege1-3", "id": 3}']->(v6),
-	   (v1)<-[:regelabel2 '{"name": "rege2-1", "id": 4}']-(v8),
-	   (v2)<-[:regelabel2 '{"name": "rege2-2", "id": 5}']-(v7),
-	   (v3)<-[:regelabel2 '{"name": "rege2-3", "id": 6}']-(v6);
+CREATE (v1:regvlabel1 {'name': 'regv1-1', 'id': 1}),
+	   (v2:regvlabel1 {'name': 'regv1-2', 'id': 2}),
+	   (v3:regvlabel1 {'name': 'regv1-3', 'id': 3}),
+	   (v4:regvlabel2 {'name': 'regv2-1', 'id': 4}),
+	   (v5:regvlabel2 {'name': 'regv2-2', 'id': 5}),
+	   (v6:regvlabel2 {'name': 'regv2-3', 'id': 6}),
+	   (v7:regvlabel2 {'name': 'regv2-4', 'id': 7}),
+	   (v8:regvlabel2 {'name': 'regv2-5', 'id': 8}),
+	   (v1)-[:regelabel1 {'name': 'rege1-1', 'id': 1}]->(v4),
+	   (v2)-[:regelabel1 {'name': 'rege1-2', 'id': 2}]->(v5),
+	   (v3)-[:regelabel1 {'name': 'rege1-3', 'id': 3}]->(v6),
+	   (v1)<-[:regelabel2 {'name': 'rege2-1', 'id': 4}]-(v8),
+	   (v2)<-[:regelabel2 {'name': 'rege2-2', 'id': 5}]-(v7),
+	   (v3)<-[:regelabel2 {'name': 'rege2-3', 'id': 6}]-(v6);
 --
 -- MATCH & RETURN clause
 --
@@ -375,8 +375,8 @@ NOTICE:  merging column "id" with inherited definition
 CREATE (),
 	   (a),
 	   (b:regvlabel1),
-	   (c:regvlabel2 '{"name": "test1"}'),
-	   p=(d:regvlabel3 '{"name": "test2", "age": 123}')-[:regelabel1]->();
+	   (c:regvlabel2 {'name': 'test1'}),
+	   p=(d:regvlabel3 {'name': 'test2', 'age': 123})-[:regelabel1]->();
 MATCH (a) RETURN (id(a)).lid, properties(a);
  lid |          properties           
 -----+-------------------------------
@@ -390,9 +390,9 @@ MATCH (a) RETURN (id(a)).lid, properties(a);
 
 MATCH (n) DETACH DELETE n;
 -- refer previous variable
-CREATE (a:regvlabel1 '{"name": "elem1"}'),
-	   (a)-[d:regelabel1 '{"rel": 1}']->(b:regvlabel2 '{"name": "elem2"}'),
-	   (b)<-[e:regelabel2 '{"rel": 2}']-(c:regvlabel2 '{"name": "elem3"}')
+CREATE (a:regvlabel1 {'name': 'elem1'}),
+	   (a)-[d:regelabel1 {'rel': 1}]->(b:regvlabel2 {'name': 'elem2'}),
+	   (b)<-[e:regelabel2 {'rel': 2}]-(c:regvlabel2 {'name': 'elem3'})
 RETURN properties(a), properties(d), properties(b), properties(e), properties(c);
     properties     | properties |    properties     | properties |    properties     
 -------------------+------------+-------------------+------------+-------------------
@@ -411,8 +411,8 @@ RETURN properties(a), properties(b), properties(c);
 
 MATCH (n) DETACH DELETE n;
 -- relationship
-CREATE (a:regvlabel1 '{"name": "insert v1-1"}')-[b:regelabel1]->(c:regvlabel2 '{"name": "insert v2-1"}');
-CREATE (a:regvlabel1 '{"name": "insert v1-2"}')<-[b:regelabel1]-(c:regvlabel2 '{"name": "insert v2-2"}');
+CREATE (a:regvlabel1 {'name': 'insert v1-1'})-[b:regelabel1]->(c:regvlabel2 {'name': 'insert v2-1'});
+CREATE (a:regvlabel1 {'name': 'insert v1-2'})<-[b:regelabel1]-(c:regvlabel2 {'name': 'insert v2-2'});
 MATCH (a)<-[b]->(c)
 RETURN properties(a), properties(b), properties(c);
        properties        | properties |       properties        
@@ -424,12 +424,12 @@ RETURN properties(a), properties(b), properties(c);
 (4 rows)
 
 -- bi-directional relationship
-CREATE (:regvlabel2 '{"name": "regvlabel2-1"}'),
-	   (:regvlabel2 '{"name": "regvlabel2-2"}'),
-	   (:regvlabel2 '{"name": "regvlabel2-3"}');
-CREATE (a:regvlabel1 '{"name": "regvlabel1"}')
+CREATE (:regvlabel2 {'name': 'regvlabel2-1'}),
+	   (:regvlabel2 {'name': 'regvlabel2-2'}),
+	   (:regvlabel2 {'name': 'regvlabel2-3'});
+CREATE (a:regvlabel1 {'name': 'regvlabel1'})
 MATCH (b:regvlabel2)
-CREATE (a)-[c:regelabel1 '{"name": "e1"}']->(b), (b)-[d:regelabel1 '{"name": "e2"}']->(a)
+CREATE (a)-[c:regelabel1 {'name': 'e1'}]->(b), (b)-[d:regelabel1 {'name': 'e2'}]->(a)
 RETURN id(a) = start(c) AND "end"(c) = id(b) AS atob,
 	   id(b) = start(d) AND "end"(d) = id(a) AS btoa;
  atob | btoa 
@@ -455,17 +455,17 @@ CREATE (a:regvlabel1:regvlabel2);
 ERROR:  syntax error at or near ":"
 LINE 1: CREATE (a:regvlabel1:regvlabel2);
                             ^
-CREATE (:regvlabel1)-['{"reltype": "empty"}']->(:regvlabel2);
+CREATE (:regvlabel1)-[{'reltype': 'empty'}]->(:regvlabel2);
 ERROR:  a single relationship type must be specified for CREATE
 -- wrong cases (bi-directional relationship)
-CREATE (:regvlabel1 '{"name": "insert v1-3"}')-[:regelabel1]-(:regvlabel2 '{"name": "insert v2-3"}');
+CREATE (:regvlabel1 {'name': 'insert v1-3'})-[:regelabel1]-(:regvlabel2 {'name': 'insert v2-3'});
 ERROR:  only directed relationships are allowed in CREATE
-CREATE (:regvlabel1 '{"name": "insert v1-4"}')<-[:regelabel1]->(:regvlabel2 '{"name": "insert v2-4"}');
+CREATE (:regvlabel1 {'name': 'insert v1-4'})<-[:regelabel1]->(:regvlabel2 {'name': 'insert v2-4'});
 ERROR:  only directed relationships are allowed in CREATE
 -- multiple CREATE's
 MATCH (a:regvlabel1), (b:regvlabel2)
-CREATE p=(a)-[:regelabel1 '{"name": "edge1"}']->(b)
-CREATE (b)<-[:regelabel2 '{"name": "edge2"}']-(c:regvlabel3 '{"name": "v3"}')
+CREATE p=(a)-[:regelabel1 {'name': 'edge1'}]->(b)
+CREATE (b)<-[:regelabel2 {'name': 'edge2'}]-(c:regvlabel3 {'name': 'v3'})
 RETURN properties(c);
    properties   
 ----------------

--- a/src/test/regress/sql/cypher_dml.sql
+++ b/src/test/regress/sql/cypher_dml.sql
@@ -18,23 +18,23 @@ CREATE vlabel regvlabel3;
 CREATE elabel regelabel1;
 CREATE elabel regelabel2;
 
-CREATE (v1:regvlabel1 '{"name": "regv1-1", "id": 1}'),
-	   (v2:regvlabel1 '{"name": "regv1-2", "id": 2}'),
-	   (v3:regvlabel1 '{"name": "regv1-3", "id": 3}'),
+CREATE (v1:regvlabel1 {'name': 'regv1-1', 'id': 1}),
+	   (v2:regvlabel1 {'name': 'regv1-2', 'id': 2}),
+	   (v3:regvlabel1 {'name': 'regv1-3', 'id': 3}),
 
-	   (v4:regvlabel2 '{"name": "regv2-1", "id": 4}'),
-	   (v5:regvlabel2 '{"name": "regv2-2", "id": 5}'),
-	   (v6:regvlabel2 '{"name": "regv2-3", "id": 6}'),
-	   (v7:regvlabel2 '{"name": "regv2-4", "id": 7}'),
-	   (v8:regvlabel2 '{"name": "regv2-5", "id": 8}'),
+	   (v4:regvlabel2 {'name': 'regv2-1', 'id': 4}),
+	   (v5:regvlabel2 {'name': 'regv2-2', 'id': 5}),
+	   (v6:regvlabel2 {'name': 'regv2-3', 'id': 6}),
+	   (v7:regvlabel2 {'name': 'regv2-4', 'id': 7}),
+	   (v8:regvlabel2 {'name': 'regv2-5', 'id': 8}),
 
-	   (v1)-[:regelabel1 '{"name": "rege1-1", "id": 1}']->(v4),
-	   (v2)-[:regelabel1 '{"name": "rege1-2", "id": 2}']->(v5),
-	   (v3)-[:regelabel1 '{"name": "rege1-3", "id": 3}']->(v6),
+	   (v1)-[:regelabel1 {'name': 'rege1-1', 'id': 1}]->(v4),
+	   (v2)-[:regelabel1 {'name': 'rege1-2', 'id': 2}]->(v5),
+	   (v3)-[:regelabel1 {'name': 'rege1-3', 'id': 3}]->(v6),
 
-	   (v1)<-[:regelabel2 '{"name": "rege2-1", "id": 4}']-(v8),
-	   (v2)<-[:regelabel2 '{"name": "rege2-2", "id": 5}']-(v7),
-	   (v3)<-[:regelabel2 '{"name": "rege2-3", "id": 6}']-(v6);
+	   (v1)<-[:regelabel2 {'name': 'rege2-1', 'id': 4}]-(v8),
+	   (v2)<-[:regelabel2 {'name': 'rege2-2', 'id': 5}]-(v7),
+	   (v3)<-[:regelabel2 {'name': 'rege2-3', 'id': 6}]-(v6);
 
 --
 -- MATCH & RETURN clause
@@ -195,8 +195,8 @@ CREATE elabel regelabel2;
 CREATE (),
 	   (a),
 	   (b:regvlabel1),
-	   (c:regvlabel2 '{"name": "test1"}'),
-	   p=(d:regvlabel3 '{"name": "test2", "age": 123}')-[:regelabel1]->();
+	   (c:regvlabel2 {'name': 'test1'}),
+	   p=(d:regvlabel3 {'name': 'test2', 'age': 123})-[:regelabel1]->();
 
 MATCH (a) RETURN (id(a)).lid, properties(a);
 
@@ -204,9 +204,9 @@ MATCH (n) DETACH DELETE n;
 
 -- refer previous variable
 
-CREATE (a:regvlabel1 '{"name": "elem1"}'),
-	   (a)-[d:regelabel1 '{"rel": 1}']->(b:regvlabel2 '{"name": "elem2"}'),
-	   (b)<-[e:regelabel2 '{"rel": 2}']-(c:regvlabel2 '{"name": "elem3"}')
+CREATE (a:regvlabel1 {'name': 'elem1'}),
+	   (a)-[d:regelabel1 {'rel': 1}]->(b:regvlabel2 {'name': 'elem2'}),
+	   (b)<-[e:regelabel2 {'rel': 2}]-(c:regvlabel2 {'name': 'elem3'})
 RETURN properties(a), properties(d), properties(b), properties(e), properties(c);
 
 MATCH (a)-[b]-(c)
@@ -216,21 +216,21 @@ MATCH (n) DETACH DELETE n;
 
 -- relationship
 
-CREATE (a:regvlabel1 '{"name": "insert v1-1"}')-[b:regelabel1]->(c:regvlabel2 '{"name": "insert v2-1"}');
-CREATE (a:regvlabel1 '{"name": "insert v1-2"}')<-[b:regelabel1]-(c:regvlabel2 '{"name": "insert v2-2"}');
+CREATE (a:regvlabel1 {'name': 'insert v1-1'})-[b:regelabel1]->(c:regvlabel2 {'name': 'insert v2-1'});
+CREATE (a:regvlabel1 {'name': 'insert v1-2'})<-[b:regelabel1]-(c:regvlabel2 {'name': 'insert v2-2'});
 
 MATCH (a)<-[b]->(c)
 RETURN properties(a), properties(b), properties(c);
 
 -- bi-directional relationship
 
-CREATE (:regvlabel2 '{"name": "regvlabel2-1"}'),
-	   (:regvlabel2 '{"name": "regvlabel2-2"}'),
-	   (:regvlabel2 '{"name": "regvlabel2-3"}');
+CREATE (:regvlabel2 {'name': 'regvlabel2-1'}),
+	   (:regvlabel2 {'name': 'regvlabel2-2'}),
+	   (:regvlabel2 {'name': 'regvlabel2-3'});
 
-CREATE (a:regvlabel1 '{"name": "regvlabel1"}')
+CREATE (a:regvlabel1 {'name': 'regvlabel1'})
 MATCH (b:regvlabel2)
-CREATE (a)-[c:regelabel1 '{"name": "e1"}']->(b), (b)-[d:regelabel1 '{"name": "e2"}']->(a)
+CREATE (a)-[c:regelabel1 {'name': 'e1'}]->(b), (b)-[d:regelabel1 {'name': 'e2'}]->(a)
 RETURN id(a) = start(c) AND "end"(c) = id(b) AS atob,
 	   id(b) = start(d) AND "end"(d) = id(a) AS btoa;
 
@@ -240,16 +240,16 @@ CREATE (a:regvlabel1), (b:regvlabel2), (a:regvlabel);
 
 -- wrong cases (label)
 CREATE (a:regvlabel1:regvlabel2);
-CREATE (:regvlabel1)-['{"reltype": "empty"}']->(:regvlabel2);
+CREATE (:regvlabel1)-[{'reltype': 'empty'}]->(:regvlabel2);
 
 -- wrong cases (bi-directional relationship)
-CREATE (:regvlabel1 '{"name": "insert v1-3"}')-[:regelabel1]-(:regvlabel2 '{"name": "insert v2-3"}');
-CREATE (:regvlabel1 '{"name": "insert v1-4"}')<-[:regelabel1]->(:regvlabel2 '{"name": "insert v2-4"}');
+CREATE (:regvlabel1 {'name': 'insert v1-3'})-[:regelabel1]-(:regvlabel2 {'name': 'insert v2-3'});
+CREATE (:regvlabel1 {'name': 'insert v1-4'})<-[:regelabel1]->(:regvlabel2 {'name': 'insert v2-4'});
 
 -- multiple CREATE's
 MATCH (a:regvlabel1), (b:regvlabel2)
-CREATE p=(a)-[:regelabel1 '{"name": "edge1"}']->(b)
-CREATE (b)<-[:regelabel2 '{"name": "edge2"}']-(c:regvlabel3 '{"name": "v3"}')
+CREATE p=(a)-[:regelabel1 {'name': 'edge1'}]->(b)
+CREATE (b)<-[:regelabel2 {'name': 'edge2'}]-(c:regvlabel3 {'name': 'v3'})
 RETURN properties(c);
 
 -- cleanup


### PR DESCRIPTION
You can make `jsonb` object in any expressions through the following
syntax; `{expr: expr, ...}`. This is just a syntactic sugar for
`jsonb_build_object(expr, expr, ...)`.
    
`jsonb` is aware of following types;
* `date`
* `timestamp`
* `timestamptz`
* ARRAY
* composite types
    
Although JSON supports array of mixed types, `expr` for an array in the
current implementation is restricted to the PostgreSQL's `ARRAY[...]`
expression.