### PR TITLE
feat: Support an expression as a property map in the pattern element

### DIFF
--- a/src/backend/executor/nodeModifyGraph.c
+++ b/src/backend/executor/nodeModifyGraph.c
@@ -455,6 +455,7 @@ evalPropMap(ExprState *prop_map, ExprContext *econtext, TupleTableSlot *slot)
 	Datum		datum;
 	bool		isNull;
 	ExprDoneCond isDone;
+	Jsonb	   *jsonb;
 
 	if (prop_map == NULL)
 		return jsonb_build_object_noargs(NULL);
@@ -474,6 +475,12 @@ evalPropMap(ExprState *prop_map, ExprContext *econtext, TupleTableSlot *slot)
 		ereport(ERROR,
 				(errcode(ERRCODE_SYNTAX_ERROR),
 				 errmsg("single result is expected for property map")));
+
+	jsonb = DatumGetJsonb(datum);
+	if (!JB_ROOT_IS_OBJECT(jsonb))
+		ereport(ERROR,
+				(errcode(ERRCODE_DATATYPE_MISMATCH),
+				 errmsg("jsonb object is expected for property map")));
 
 	return datum;
 }

--- a/src/backend/parser/gram.y
+++ b/src/backend/parser/gram.y
@@ -14361,6 +14361,7 @@ cypher_label_opt:
 cypher_prop_map_opt:
 			json_object_expr
 			| Sconst			{ $$ = makeStringConst($1, @1); }
+			| '=' a_expr		{ $$ = $2; }
 			| /* EMPTY */		{ $$ = NULL; }
 		;
 


### PR DESCRIPTION
You can write an expression as a property map using `=expr`.
For example, `(n:person =jsonb_build_object('name', 'someone'))` for
a node. The result of `=expr` must be `jsonb` type.