### PR TITLE
chore: Remove merge id column message after CREATE LABEL

### DIFF
--- a/src/include/commands/graphcmds.h
+++ b/src/include/commands/graphcmds.h
@@ -19,5 +19,6 @@ extern void RemoveGraphById(Oid graphid);
 extern void CreateLabelCommand(CreateLabelStmt *labelStmt,
 							   const char *queryString, ParamListInfo params);
 extern void CheckDropLabel(ObjectType removeType, Oid labid);
+extern bool isLabel(RangeVar *rel);
 
 #endif	/* GRAPHCMDS_H */

--- a/src/test/regress/expected/cypher_ddl.out
+++ b/src/test/regress/expected/cypher_ddl.out
@@ -20,33 +20,18 @@ SELECT graphname, labname, labkind FROM ag_label;
 -- CREATE/DROP labels
 --
 CREATE VLABEL vlabel_p1;
-NOTICE:  merging column "id" with inherited definition
 CREATE VLABEL vlabel_p2;
-NOTICE:  merging column "id" with inherited definition
 CREATE VLABEL vlabel_c1 inherits (vlabel_p1);
-NOTICE:  merging column "id" with inherited definition
 CREATE VLABEL vlabel_c2 inherits (vlabel_c1);
-NOTICE:  merging column "id" with inherited definition
 CREATE VLABEL vlabel_c3 inherits (vlabel_c2);
-NOTICE:  merging column "id" with inherited definition
 CREATE VLABEL vlabel_c4 inherits (vlabel_c3);
-NOTICE:  merging column "id" with inherited definition
 CREATE VLABEL vlabel_c5 inherits (vlabel_c4);
-NOTICE:  merging column "id" with inherited definition
 CREATE VLABEL vlabel_c6 inherits (vlabel_c4);
-NOTICE:  merging column "id" with inherited definition
 CREATE VLABEL vlabel_c7 inherits (vlabel_c1, vlabel_p2);
-NOTICE:  merging multiple inherited definitions of column "id"
-NOTICE:  merging multiple inherited definitions of column "properties"
-NOTICE:  merging column "id" with inherited definition
 CREATE ELABEL elabel_p1;
-NOTICE:  merging column "id" with inherited definition
 CREATE ELABEL elabel_c1 inherits (elabel_p1);
-NOTICE:  merging column "id" with inherited definition
 CREATE ELABEL elabel_c2 inherits (elabel_c1);
-NOTICE:  merging column "id" with inherited definition
 CREATE ELABEL elabel_c3 inherits (elabel_c2);
-NOTICE:  merging column "id" with inherited definition
 SELECT labname, labkind FROM ag_label;
   labname  | labkind 
 -----------+---------
@@ -129,10 +114,8 @@ WHERE childlab.relid = inh.inhrelid AND parentlab.relid = inh.inhparent;
 
 -- wrong cases
 CREATE VLABEL wrong_parent inherits (elabel_p1);
-NOTICE:  merging column "id" with inherited definition
 ERROR:  parent label has different labkind 'v'
 CREATE ELABEL wrong_parent inherits (vlabel_p1);
-NOTICE:  merging column "id" with inherited definition
 ERROR:  parent label has different labkind 'e'
 DROP TABLE vlabel_c7;
 ERROR:  table "vlabel_c7" does not exist

--- a/src/test/regress/expected/cypher_dml.out
+++ b/src/test/regress/expected/cypher_dml.out
@@ -41,11 +41,8 @@ SELECT * FROM (RETURN 3 + 4, 'hello' || ' agens') AS _(lucky, greeting);
 -- CREATE
 --
 CREATE VLABEL repo;
-NOTICE:  merging column "id" with inherited definition
 CREATE ELABEL lib;
-NOTICE:  merging column "id" with inherited definition
 CREATE ELABEL doc;
-NOTICE:  merging column "id" with inherited definition
 CREATE (g:repo {'name': 'agens-graph',
                 'year': (SELECT year FROM history WHERE event = 'Graph')})
 RETURN properties(g) AS g;
@@ -490,9 +487,7 @@ MATCH (a:repo) RETURN (a).name AS a, size((a)-[]->()) AS s;
 MATCH (a) LOAD FROM history AS a RETURN *;
 ERROR:  duplicate variable "a"
 CREATE VLABEL feature;
-NOTICE:  merging column "id" with inherited definition
 CREATE ELABEL supported;
-NOTICE:  merging column "id" with inherited definition
 MATCH (a:repo {'name': 'agens-graph'})
 LOAD FROM history AS h
 CREATE (:feature {'name': (h).event})-[:supported]->(a);


### PR DESCRIPTION
Add function to distinguish label from table.
And fix to do not print message with label.