### PR TITLE
feat: Remove unnecessary JOINs for empty nodes

### DIFF
--- a/src/test/regress/expected/cypher_dml.out
+++ b/src/test/regress/expected/cypher_dml.out
@@ -157,83 +157,88 @@ MATCH (a:repo) RETURN (a).name AS name, (a)['year'] AS year;
 (4 rows)
 
 MATCH p=(a)-[b]-(c)
-RETURN (a).name AS a, (b).lang AS b, (c).name AS c;
+RETURN (a).name AS a, (b).lang AS b, (c).name AS c
+       ORDER BY a, b, c;
          a          |   b    |         c          
 --------------------+--------+--------------------
- "agens-graph"      | "Java" | "agens-graph-jdbc"
- "agens-graph"      | "en"   | "agens-graph-docs"
  "agens-graph"      | "C"    | "agens-graph-odbc"
- "agens-graph-jdbc" | "Java" | "agens-graph"
+ "agens-graph"      | "en"   | "agens-graph-docs"
+ "agens-graph"      | "Java" | "agens-graph-jdbc"
  "agens-graph-docs" | "en"   | "agens-graph"
+ "agens-graph-jdbc" | "Java" | "agens-graph"
  "agens-graph-odbc" | "C"    | "agens-graph"
 (6 rows)
 
 MATCH (a)<-[b]-(c)-[d]->(e)
 RETURN (a).name AS a, (b).lang AS b, (c).name AS c,
-       (d).lang AS d, (e).name AS e;
+       (d).lang AS d, (e).name AS e
+       ORDER BY a, b, c, d, e;
          a          |   b    |       c       |   d    |         e          
 --------------------+--------+---------------+--------+--------------------
- "agens-graph-jdbc" | "Java" | "agens-graph" | "en"   | "agens-graph-docs"
- "agens-graph-jdbc" | "Java" | "agens-graph" | "C"    | "agens-graph-odbc"
- "agens-graph-docs" | "en"   | "agens-graph" | "Java" | "agens-graph-jdbc"
  "agens-graph-docs" | "en"   | "agens-graph" | "C"    | "agens-graph-odbc"
- "agens-graph-odbc" | "C"    | "agens-graph" | "Java" | "agens-graph-jdbc"
+ "agens-graph-docs" | "en"   | "agens-graph" | "Java" | "agens-graph-jdbc"
+ "agens-graph-jdbc" | "Java" | "agens-graph" | "C"    | "agens-graph-odbc"
+ "agens-graph-jdbc" | "Java" | "agens-graph" | "en"   | "agens-graph-docs"
  "agens-graph-odbc" | "C"    | "agens-graph" | "en"   | "agens-graph-docs"
+ "agens-graph-odbc" | "C"    | "agens-graph" | "Java" | "agens-graph-jdbc"
 (6 rows)
 
 MATCH (a)<-[b]-(c), (c)-[d]->(e)
 RETURN (a).name AS a, (b).lang AS b, (c).name AS c,
-       (d).lang AS d, (e).name AS e;
+       (d).lang AS d, (e).name AS e
+       ORDER BY a, b, c, d, e;
          a          |   b    |       c       |   d    |         e          
 --------------------+--------+---------------+--------+--------------------
- "agens-graph-jdbc" | "Java" | "agens-graph" | "en"   | "agens-graph-docs"
- "agens-graph-jdbc" | "Java" | "agens-graph" | "C"    | "agens-graph-odbc"
- "agens-graph-docs" | "en"   | "agens-graph" | "Java" | "agens-graph-jdbc"
  "agens-graph-docs" | "en"   | "agens-graph" | "C"    | "agens-graph-odbc"
- "agens-graph-odbc" | "C"    | "agens-graph" | "Java" | "agens-graph-jdbc"
+ "agens-graph-docs" | "en"   | "agens-graph" | "Java" | "agens-graph-jdbc"
+ "agens-graph-jdbc" | "Java" | "agens-graph" | "C"    | "agens-graph-odbc"
+ "agens-graph-jdbc" | "Java" | "agens-graph" | "en"   | "agens-graph-docs"
  "agens-graph-odbc" | "C"    | "agens-graph" | "en"   | "agens-graph-docs"
+ "agens-graph-odbc" | "C"    | "agens-graph" | "Java" | "agens-graph-jdbc"
 (6 rows)
 
 MATCH (a)<-[b]-(c) MATCH (c)-[d]->(e)
 RETURN (a).name AS a, (b).lang AS b, (c).name AS c,
-       (d).lang AS d, (e).name AS e;
+       (d).lang AS d, (e).name AS e
+       ORDER BY a, b, c, d, e;
          a          |   b    |       c       |   d    |         e          
 --------------------+--------+---------------+--------+--------------------
- "agens-graph-jdbc" | "Java" | "agens-graph" | "Java" | "agens-graph-jdbc"
- "agens-graph-jdbc" | "Java" | "agens-graph" | "en"   | "agens-graph-docs"
- "agens-graph-jdbc" | "Java" | "agens-graph" | "C"    | "agens-graph-odbc"
- "agens-graph-docs" | "en"   | "agens-graph" | "Java" | "agens-graph-jdbc"
- "agens-graph-docs" | "en"   | "agens-graph" | "en"   | "agens-graph-docs"
  "agens-graph-docs" | "en"   | "agens-graph" | "C"    | "agens-graph-odbc"
- "agens-graph-odbc" | "C"    | "agens-graph" | "Java" | "agens-graph-jdbc"
- "agens-graph-odbc" | "C"    | "agens-graph" | "en"   | "agens-graph-docs"
+ "agens-graph-docs" | "en"   | "agens-graph" | "en"   | "agens-graph-docs"
+ "agens-graph-docs" | "en"   | "agens-graph" | "Java" | "agens-graph-jdbc"
+ "agens-graph-jdbc" | "Java" | "agens-graph" | "C"    | "agens-graph-odbc"
+ "agens-graph-jdbc" | "Java" | "agens-graph" | "en"   | "agens-graph-docs"
+ "agens-graph-jdbc" | "Java" | "agens-graph" | "Java" | "agens-graph-jdbc"
  "agens-graph-odbc" | "C"    | "agens-graph" | "C"    | "agens-graph-odbc"
+ "agens-graph-odbc" | "C"    | "agens-graph" | "en"   | "agens-graph-docs"
+ "agens-graph-odbc" | "C"    | "agens-graph" | "Java" | "agens-graph-jdbc"
 (9 rows)
 
 MATCH (a)<-[b]-(c), (f)-[g]->(h), (c)-[d]->(e)
 RETURN (a).name AS a, (b).lang AS b, (c).name AS c,
        (d).lang AS d, (e).name AS e,
-       (f).name AS f, (g).lang AS g, (h).name AS h;
+       (f).name AS f, (g).lang AS g, (h).name AS h
+       ORDER BY a, b, c, d, e, f, g, h;
          a          |   b    |       c       |   d    |         e          |       f       |   g    |         h          
 --------------------+--------+---------------+--------+--------------------+---------------+--------+--------------------
- "agens-graph-docs" | "en"   | "agens-graph" | "Java" | "agens-graph-jdbc" | "agens-graph" | "en"   | "agens-graph-docs"
- "agens-graph-docs" | "en"   | "agens-graph" | "Java" | "agens-graph-jdbc" | "agens-graph" | "Java" | "agens-graph-jdbc"
- "agens-graph-docs" | "en"   | "agens-graph" | "Java" | "agens-graph-jdbc" | "agens-graph" | "C"    | "agens-graph-odbc"
- "agens-graph-odbc" | "C"    | "agens-graph" | "Java" | "agens-graph-jdbc" | "agens-graph" | "en"   | "agens-graph-docs"
- "agens-graph-odbc" | "C"    | "agens-graph" | "Java" | "agens-graph-jdbc" | "agens-graph" | "Java" | "agens-graph-jdbc"
- "agens-graph-odbc" | "C"    | "agens-graph" | "Java" | "agens-graph-jdbc" | "agens-graph" | "C"    | "agens-graph-odbc"
- "agens-graph-jdbc" | "Java" | "agens-graph" | "en"   | "agens-graph-docs" | "agens-graph" | "Java" | "agens-graph-jdbc"
- "agens-graph-jdbc" | "Java" | "agens-graph" | "en"   | "agens-graph-docs" | "agens-graph" | "C"    | "agens-graph-odbc"
- "agens-graph-jdbc" | "Java" | "agens-graph" | "en"   | "agens-graph-docs" | "agens-graph" | "en"   | "agens-graph-docs"
- "agens-graph-odbc" | "C"    | "agens-graph" | "en"   | "agens-graph-docs" | "agens-graph" | "Java" | "agens-graph-jdbc"
- "agens-graph-odbc" | "C"    | "agens-graph" | "en"   | "agens-graph-docs" | "agens-graph" | "C"    | "agens-graph-odbc"
- "agens-graph-odbc" | "C"    | "agens-graph" | "en"   | "agens-graph-docs" | "agens-graph" | "en"   | "agens-graph-docs"
- "agens-graph-jdbc" | "Java" | "agens-graph" | "C"    | "agens-graph-odbc" | "agens-graph" | "en"   | "agens-graph-docs"
- "agens-graph-jdbc" | "Java" | "agens-graph" | "C"    | "agens-graph-odbc" | "agens-graph" | "Java" | "agens-graph-jdbc"
- "agens-graph-jdbc" | "Java" | "agens-graph" | "C"    | "agens-graph-odbc" | "agens-graph" | "C"    | "agens-graph-odbc"
+ "agens-graph-docs" | "en"   | "agens-graph" | "C"    | "agens-graph-odbc" | "agens-graph" | "C"    | "agens-graph-odbc"
  "agens-graph-docs" | "en"   | "agens-graph" | "C"    | "agens-graph-odbc" | "agens-graph" | "en"   | "agens-graph-docs"
  "agens-graph-docs" | "en"   | "agens-graph" | "C"    | "agens-graph-odbc" | "agens-graph" | "Java" | "agens-graph-jdbc"
- "agens-graph-docs" | "en"   | "agens-graph" | "C"    | "agens-graph-odbc" | "agens-graph" | "C"    | "agens-graph-odbc"
+ "agens-graph-docs" | "en"   | "agens-graph" | "Java" | "agens-graph-jdbc" | "agens-graph" | "C"    | "agens-graph-odbc"
+ "agens-graph-docs" | "en"   | "agens-graph" | "Java" | "agens-graph-jdbc" | "agens-graph" | "en"   | "agens-graph-docs"
+ "agens-graph-docs" | "en"   | "agens-graph" | "Java" | "agens-graph-jdbc" | "agens-graph" | "Java" | "agens-graph-jdbc"
+ "agens-graph-jdbc" | "Java" | "agens-graph" | "C"    | "agens-graph-odbc" | "agens-graph" | "C"    | "agens-graph-odbc"
+ "agens-graph-jdbc" | "Java" | "agens-graph" | "C"    | "agens-graph-odbc" | "agens-graph" | "en"   | "agens-graph-docs"
+ "agens-graph-jdbc" | "Java" | "agens-graph" | "C"    | "agens-graph-odbc" | "agens-graph" | "Java" | "agens-graph-jdbc"
+ "agens-graph-jdbc" | "Java" | "agens-graph" | "en"   | "agens-graph-docs" | "agens-graph" | "C"    | "agens-graph-odbc"
+ "agens-graph-jdbc" | "Java" | "agens-graph" | "en"   | "agens-graph-docs" | "agens-graph" | "en"   | "agens-graph-docs"
+ "agens-graph-jdbc" | "Java" | "agens-graph" | "en"   | "agens-graph-docs" | "agens-graph" | "Java" | "agens-graph-jdbc"
+ "agens-graph-odbc" | "C"    | "agens-graph" | "en"   | "agens-graph-docs" | "agens-graph" | "C"    | "agens-graph-odbc"
+ "agens-graph-odbc" | "C"    | "agens-graph" | "en"   | "agens-graph-docs" | "agens-graph" | "en"   | "agens-graph-docs"
+ "agens-graph-odbc" | "C"    | "agens-graph" | "en"   | "agens-graph-docs" | "agens-graph" | "Java" | "agens-graph-jdbc"
+ "agens-graph-odbc" | "C"    | "agens-graph" | "Java" | "agens-graph-jdbc" | "agens-graph" | "C"    | "agens-graph-odbc"
+ "agens-graph-odbc" | "C"    | "agens-graph" | "Java" | "agens-graph-jdbc" | "agens-graph" | "en"   | "agens-graph-docs"
+ "agens-graph-odbc" | "C"    | "agens-graph" | "Java" | "agens-graph-jdbc" | "agens-graph" | "Java" | "agens-graph-jdbc"
 (18 rows)
 
 MATCH (a {'name': 'agens-graph'}), (a {'year': 2016}) RETURN properties(a) AS a;
@@ -288,7 +293,7 @@ LINE 1: MATCH (a =0) RETURN *;
 MATCH ()-[a]-(a) RETURN *;
 ERROR:  duplicate variable "a"
 LINE 1: MATCH ()-[a]-(a) RETURN *;
-                  ^
+                      ^
 MATCH ()-[a]-()-[a]-() RETURN *;
 ERROR:  duplicate variable "a"
 LINE 1: MATCH ()-[a]-()-[a]-() RETURN *;

--- a/src/test/regress/sql/cypher_dml.sql
+++ b/src/test/regress/sql/cypher_dml.sql
@@ -77,24 +77,29 @@ CREATE ();
 MATCH (a:repo) RETURN (a).name AS name, (a)['year'] AS year;
 
 MATCH p=(a)-[b]-(c)
-RETURN (a).name AS a, (b).lang AS b, (c).name AS c;
+RETURN (a).name AS a, (b).lang AS b, (c).name AS c
+       ORDER BY a, b, c;
 
 MATCH (a)<-[b]-(c)-[d]->(e)
 RETURN (a).name AS a, (b).lang AS b, (c).name AS c,
-       (d).lang AS d, (e).name AS e;
+       (d).lang AS d, (e).name AS e
+       ORDER BY a, b, c, d, e;
 
 MATCH (a)<-[b]-(c), (c)-[d]->(e)
 RETURN (a).name AS a, (b).lang AS b, (c).name AS c,
-       (d).lang AS d, (e).name AS e;
+       (d).lang AS d, (e).name AS e
+       ORDER BY a, b, c, d, e;
 
 MATCH (a)<-[b]-(c) MATCH (c)-[d]->(e)
 RETURN (a).name AS a, (b).lang AS b, (c).name AS c,
-       (d).lang AS d, (e).name AS e;
+       (d).lang AS d, (e).name AS e
+       ORDER BY a, b, c, d, e;
 
 MATCH (a)<-[b]-(c), (f)-[g]->(h), (c)-[d]->(e)
 RETURN (a).name AS a, (b).lang AS b, (c).name AS c,
        (d).lang AS d, (e).name AS e,
-       (f).name AS f, (g).lang AS g, (h).name AS h;
+       (f).name AS f, (g).lang AS g, (h).name AS h
+       ORDER BY a, b, c, d, e, f, g, h;
 
 MATCH (a {'name': 'agens-graph'}), (a {'year': 2016}) RETURN properties(a) AS a;
 MATCH p=(a)-[]->({'name': 'agens-graph-jdbc'}) RETURN (a).name AS a;


### PR DESCRIPTION
example query: `EXPLAIN MATCH ()-[r]->() RETURN r;`