### PR TITLE
feat: Set `graph_path` adaptively

### DIFF
--- a/src/test/regress/expected/cypher_ddl.out
+++ b/src/test/regress/expected/cypher_ddl.out
@@ -5,15 +5,6 @@
 -- CREATE graph
 --
 CREATE GRAPH mygraph;
--- before set graph_path
-CREATE VLABEL nopath;
-ERROR:  the graph_path is NULL
-HINT:  Use SET graph_path
--- after set graph_path
-set graph_path=mygraph;
-CREATE VLABEL yespath;
-NOTICE:  merging column "id" with inherited definition
-DROP VLABEL yespath;
 -- cannot set multi path
 set graph_path=mygraph,urgraph;
 ERROR:  SET graph_path takes only one argument

--- a/src/test/regress/expected/cypher_dml.out
+++ b/src/test/regress/expected/cypher_dml.out
@@ -10,7 +10,6 @@ CREATE TABLE history (year, event) AS VALUES
 DROP GRAPH agens;
 ERROR:  graph "agens" does not exist
 CREATE GRAPH agens;
-set graph_path=agens;
 --
 -- RETURN
 --

--- a/src/test/regress/sql/cypher_ddl.sql
+++ b/src/test/regress/sql/cypher_ddl.sql
@@ -8,17 +8,6 @@
 
 CREATE GRAPH mygraph;
 
--- before set graph_path
-
-CREATE VLABEL nopath;
-
--- after set graph_path
-
-set graph_path=mygraph;
-
-CREATE VLABEL yespath;
-DROP VLABEL yespath;
-
 -- cannot set multi path
 
 set graph_path=mygraph,urgraph;

--- a/src/test/regress/sql/cypher_dml.sql
+++ b/src/test/regress/sql/cypher_dml.sql
@@ -12,7 +12,6 @@ CREATE TABLE history (year, event) AS VALUES
 
 DROP GRAPH agens;
 CREATE GRAPH agens;
-set graph_path=agens;
 
 --
 -- RETURN


### PR DESCRIPTION
Set `graph_path` to the newly create graph when CREATE GRAPH succeeds
and `graph_path` is NULL, and to NULL if the dropped graph is current
`graph_path` when DROP GRAPH succeeds.