### PR TITLE
feat: Restirct SQL DDL with Graph Objects

### DIFF
--- a/src/backend/commands/graphcmds.c
+++ b/src/backend/commands/graphcmds.c
@@ -327,3 +327,18 @@ isLabel(RangeVar *rel)
 
 	return result;
 }
+
+void
+CheckInheritLabel(CreateStmt *stmt)
+{
+	ListCell   *entry;
+	foreach(entry, stmt->inhRelations)
+	{
+		RangeVar   *parent = (RangeVar *) lfirst(entry);
+
+		if (isLabel(parent))
+			ereport(ERROR,
+					(errcode(ERRCODE_INVALID_TABLE_DEFINITION),
+					 errmsg("invalid parent, table cannot inherit label")));
+	}
+}

--- a/src/backend/parser/parse_utilcmd.c
+++ b/src/backend/parser/parse_utilcmd.c
@@ -205,6 +205,10 @@ transformCreateStmt(CreateStmt *stmt, const char *queryString)
 		&& stmt->relation->relpersistence != RELPERSISTENCE_TEMP)
 		stmt->relation->schemaname = get_namespace_name(namespaceid);
 
+	if (stmt->relation->schemaname != NULL
+		&& get_graphname_graphid(stmt->relation->schemaname))
+		elog(ERROR, "cannot create table in graph schema");
+
 	/* Set up CreateStmtContext */
 	cxt.pstate = pstate;
 	if (IsA(stmt, CreateForeignTableStmt))
@@ -2393,6 +2397,9 @@ transformAlterTableStmt(Oid relid, AlterTableStmt *stmt,
 	bool		skipValidation = true;
 	AlterTableCmd *newcmd;
 	RangeTblEntry *rte;
+
+	if (isLabelOid(relid))
+		elog(ERROR, "cannot ALTER TABLE of graph label");
 
 	/*
 	 * We must not scribble on the passed-in AlterTableStmt, so copy it. (This

--- a/src/backend/tcop/utility.c
+++ b/src/backend/tcop/utility.c
@@ -964,6 +964,8 @@ ProcessUtilitySlow(Node *parsetree,
 							Datum		toast_options;
 							static char *validnsps[] = HEAP_RELOPT_NAMESPACES;
 
+							CheckInheritLabel((CreateStmt*)stmt);
+
 							/* Create the table itself */
 							address = DefineRelation((CreateStmt *) stmt,
 													 RELKIND_RELATION,

--- a/src/include/commands/graphcmds.h
+++ b/src/include/commands/graphcmds.h
@@ -20,5 +20,6 @@ extern void CreateLabelCommand(CreateLabelStmt *labelStmt,
 							   const char *queryString, ParamListInfo params);
 extern void CheckDropLabel(ObjectType removeType, Oid labid);
 extern bool isLabel(RangeVar *rel);
+extern void CheckInheritLabel(CreateStmt *stmt);
 
 #endif	/* GRAPHCMDS_H */

--- a/src/include/utils/lsyscache.h
+++ b/src/include/utils/lsyscache.h
@@ -160,6 +160,7 @@ extern Oid	get_range_subtype(Oid rangeOid);
 extern Oid	get_graphname_graphid(const char *graphname);
 extern Oid	get_labname_labid(const char *labname, const char *graphname);
 extern Oid	get_labid_relid(Oid labid);
+extern bool	isLabelOid(Oid relid);
 
 #define type_is_array(typid)  (get_element_type(typid) != InvalidOid)
 /* type_is_array_domain accepts both plain arrays and domains over arrays */

--- a/src/test/regress/expected/alter_table.out
+++ b/src/test/regress/expected/alter_table.out
@@ -2743,3 +2743,15 @@ ALTER TABLE logged1 SET UNLOGGED; -- silently do nothing
 DROP TABLE logged3;
 DROP TABLE logged2;
 DROP TABLE logged1;
+--
+-- ALTER TABLE restriction with AgensGraph
+--
+CREATE GRAPH mygraph;
+CREATE VLABEL v1;
+ALTER TABLE mygraph.v1 ADD COLUMN newid int;
+ERROR:  cannot ALTER TABLE of graph label
+DROP GRAPH mygraph cascade;
+NOTICE:  drop cascades to 3 other objects
+DETAIL:  drop cascades to label ag_vertex
+drop cascades to label ag_edge
+drop cascades to label v1

--- a/src/test/regress/expected/create_table.out
+++ b/src/test/regress/expected/create_table.out
@@ -250,3 +250,15 @@ ERROR:  relation "as_select1" already exists
 CREATE TABLE IF NOT EXISTS as_select1 AS SELECT * FROM pg_class WHERE relkind = 'r';
 NOTICE:  relation "as_select1" already exists, skipping
 DROP TABLE as_select1;
+--
+-- CREATE TABLE restriction with AgensGraph
+--
+CREATE GRAPH mygraph;
+CREATE TABLE mygraph.t1 (i1 int);
+ERROR:  cannot create table in graph schema
+CREATE TABLE t1 (i1 int) inherits(mygraph.ag_vertex);
+ERROR:  invalid parent, table cannot inherit label
+DROP GRAPH mygraph cascade;
+NOTICE:  drop cascades to 2 other objects
+DETAIL:  drop cascades to label ag_vertex
+drop cascades to label ag_edge

--- a/src/test/regress/sql/alter_table.sql
+++ b/src/test/regress/sql/alter_table.sql
@@ -1757,3 +1757,14 @@ ALTER TABLE logged1 SET UNLOGGED; -- silently do nothing
 DROP TABLE logged3;
 DROP TABLE logged2;
 DROP TABLE logged1;
+
+--
+-- ALTER TABLE restriction with AgensGraph
+--
+CREATE GRAPH mygraph;
+
+CREATE VLABEL v1;
+
+ALTER TABLE mygraph.v1 ADD COLUMN newid int;
+
+DROP GRAPH mygraph cascade;

--- a/src/test/regress/sql/create_table.sql
+++ b/src/test/regress/sql/create_table.sql
@@ -265,3 +265,13 @@ CREATE TABLE as_select1 AS SELECT * FROM pg_class WHERE relkind = 'r';
 CREATE TABLE as_select1 AS SELECT * FROM pg_class WHERE relkind = 'r';
 CREATE TABLE IF NOT EXISTS as_select1 AS SELECT * FROM pg_class WHERE relkind = 'r';
 DROP TABLE as_select1;
+
+--
+-- CREATE TABLE restriction with AgensGraph
+--
+CREATE GRAPH mygraph;
+
+CREATE TABLE mygraph.t1 (i1 int);
+CREATE TABLE t1 (i1 int) inherits(mygraph.ag_vertex);
+
+DROP GRAPH mygraph cascade;


### PR DESCRIPTION
Cannot CREATE TABLE in graph schemas.
Cannot inherit labels during CREATE TABLE.
Cannot ALTER TABLE to graph labels.
