### PR TITLE
fix: make `graphid` merge and hash joinable

### DIFF
--- a/src/include/catalog/pg_operator.h
+++ b/src/include/catalog/pg_operator.h
@@ -1821,7 +1821,7 @@ DATA(insert OID = 3287 (  "#-"	   PGNSP PGUID b f f 3802 1009 3802 0 0 jsonb_del
 DESCR("delete path");
 
 /* graphid operators */
-DATA(insert OID = 7087 (  "="	   PGNSP PGUID b f f 7002 7002 16 7087 7088 graphid_eq eqsel eqjoinsel ));
+DATA(insert OID = 7087 (  "="	   PGNSP PGUID b t t 7002 7002 16 7087 7088 graphid_eq eqsel eqjoinsel ));
 DESCR("equal");
 DATA(insert OID = 7088 (  "<>"	   PGNSP PGUID b f f 7002 7002 16 7088 7087 graphid_ne neqsel neqjoinsel ));
 DESCR("not equal");


### PR DESCRIPTION
`graphid` was already prepared to be used with merge/hash JOINs.
`oprcanmerge` and `oprcanhash` columns in `pg_operator` catalog was
just not properly updated.