### PR TITLE
feat: Skip unneccessary vertex label scan

### DIFF
--- a/src/backend/parser/parse_graph.c
+++ b/src/backend/parser/parse_graph.c
@@ -28,6 +28,7 @@
 #include "parser/parse_oper.h"
 #include "parser/parse_relation.h"
 #include "parser/parse_target.h"
+#include "utils/builtins.h"
 #include "utils/syscache.h"
 #include "utils/typcache.h"
 
@@ -1678,7 +1679,7 @@ getElemField(ParseState *pstate, Node *elem, char *fname)
 		Form_pg_attribute attr = NULL;
 		FieldSelect *fselect;
 
-		Assert(IsA(elem, TargetEntry));
+		AssertArg(IsA(elem, TargetEntry));
 
 		typoid = exprType((Node *) te->expr);
 		Assert(typoid == VERTEXOID || typoid == EDGEOID);
@@ -1686,11 +1687,9 @@ getElemField(ParseState *pstate, Node *elem, char *fname)
 		tupdesc = lookup_rowtype_tupdesc_copy(typoid, -1);
 		for (idx = 0; idx < tupdesc->natts; idx++)
 		{
-			char *attname;
-
 			attr = tupdesc->attrs[idx];
-			attname = NameStr(attr->attname);
-			if (strncmp(attname, fname, NAMEDATALEN) == 0)
+
+			if (namestrcmp(&attr->attname, fname) == 0)
 				break;
 		}
 		Assert(idx < tupdesc->natts);

--- a/src/include/catalog/pg_operator.h
+++ b/src/include/catalog/pg_operator.h
@@ -1823,6 +1823,7 @@ DESCR("delete path");
 /* graphid operators */
 DATA(insert OID = 7087 (  "="	   PGNSP PGUID b t t 7002 7002 16 7087 7088 graphid_eq eqsel eqjoinsel ));
 DESCR("equal");
+#define GraphidEqualOperator	7087
 DATA(insert OID = 7088 (  "<>"	   PGNSP PGUID b f f 7002 7002 16 7088 7087 graphid_ne neqsel neqjoinsel ));
 DESCR("not equal");
 DATA(insert OID = 7089 (  "<"	   PGNSP PGUID b f f 7002 7002 16 7090 7092 graphid_lt scalarltsel scalarltjoinsel ));

--- a/src/include/catalog/pg_opfamily.h
+++ b/src/include/catalog/pg_opfamily.h
@@ -184,6 +184,7 @@ DATA(insert OID = 4082 (	3580	pg_lsn_minmax_ops		PGNSP PGUID ));
 DATA(insert OID = 4104 (	3580	box_inclusion_ops		PGNSP PGUID ));
 
 DATA(insert OID = 7093 (  403 graphid_ops           PGNSP PGUID ));
+#define GRAPHID_BTREE_FAM_OID 7093
 DATA(insert OID = 7096 (  405 graphid_ops           PGNSP PGUID ));
 DATA(insert OID = 7098 ( 2742 graphid_ops           PGNSP PGUID ));
 DATA(insert OID = 7105 ( 3580 graphid_minmax_ops    PGNSP PGUID ));

--- a/src/include/executor/executor.h
+++ b/src/include/executor/executor.h
@@ -360,6 +360,8 @@ extern void UnregisterExprContextCallback(ExprContext *econtext,
 							  ExprContextCallbackFunction function,
 							  Datum arg);
 
+extern void InitScanLabelInfo(ScanState *node);
+
 /*
  * prototypes from functions in execIndexing.c
  */

--- a/src/include/nodes/execnodes.h
+++ b/src/include/nodes/execnodes.h
@@ -1258,6 +1258,12 @@ typedef struct ScanState
 	Relation	ss_currentRelation;
 	HeapScanDesc ss_currentScanDesc;
 	TupleTableSlot *ss_ScanTupleSlot;
+
+	/* to skip unneccessary graph label scan */
+	bool		ss_isLabel;			/* vertex? */
+	ExprState  *ss_labelSkipExpr;	/* SeqScan */
+	int			ss_labelSkipIdx;	/* IndexScan */
+	bool		ss_skipLabelScan;
 } ScanState;
 
 /*


### PR DESCRIPTION
When doing `SeqScan` and `IndexScan` for vertex lables, if the scan is
under JOIN operations, determine whether skip the scan or not using
`expr` in `graphid = expr` qualification condition.