### PR TITLE
fix: Restrict Cypher grammar

### DIFF
--- a/src/test/regress/expected/sql_restriction.out
+++ b/src/test/regress/expected/sql_restriction.out
@@ -34,7 +34,7 @@ ERROR:  cannot ALTER TABLE on graph label
 --
 -- TRIGGER
 --
-CREATE TRIGGER tt AFTER INSERT ON g.v 
+CREATE TRIGGER tt AFTER INSERT ON g.v
 FOR EACH STATEMENT EXECUTE PROCEDURE ff();
 ERROR:  cannot create trigger on graph label
 --


### PR DESCRIPTION
* Cypher query must end with a RETURN or an update clause.
* DELETE/SET/REMOVE clauses cannot end with a RETURN clause.
* There must be one type of consecutive update clauses.