### PR TITLE
fix: Use (tableoid, ctid) instead of graphid to ensure edge uniqueness

### DIFF
--- a/src/backend/parser/parse_utilcmd.c
+++ b/src/backend/parser/parse_utilcmd.c
@@ -3435,14 +3435,14 @@ makeEdgeIndex(RangeVar *label)
 											"idx", graphid);
 	start_idx->relation = copyObject(label);
 	start_idx->accessMethod = "btree";
-	start_idx->indexParams = list_make3(start_col, end_col, id_col);
+	start_idx->indexParams = list_make2(start_col, end_col);
 
 	end_idx = makeNode(IndexStmt);
 	end_idx->idxname = ChooseRelationName(labname, AG_END_ID,
 										  "idx", graphid);
 	end_idx->relation = copyObject(label);
 	end_idx->accessMethod = "btree";
-	end_idx->indexParams = list_make3(end_col, start_col, id_col);
+	end_idx->indexParams = list_make2(end_col, start_col);
 
 	prop_idx = makeNode(IndexStmt);
 	prop_idx->idxname = ChooseRelationName(labname, AG_ELEM_PROP_MAP,

--- a/src/backend/utils/adt/array_userfuncs.c
+++ b/src/backend/utils/adt/array_userfuncs.c
@@ -783,7 +783,8 @@ array_position_common(FunctionCallInfo fcinfo)
 					   format_type_be(element_type))));
 
 		my_extra->element_type = element_type;
-		fmgr_info(typentry->eq_opr_finfo.fn_oid, &my_extra->proc);
+		fmgr_info_cxt(typentry->eq_opr_finfo.fn_oid, &my_extra->proc,
+					  fcinfo->flinfo->fn_mcxt);
 	}
 
 	/* Examine each array element until we find a match. */
@@ -921,7 +922,8 @@ array_positions(PG_FUNCTION_ARGS)
 					   format_type_be(element_type))));
 
 		my_extra->element_type = element_type;
-		fmgr_info(typentry->eq_opr_finfo.fn_oid, &my_extra->proc);
+		fmgr_info_cxt(typentry->eq_opr_finfo.fn_oid, &my_extra->proc,
+					  fcinfo->flinfo->fn_mcxt);
 	}
 
 	/*


### PR DESCRIPTION
To use index only scan on edges without `id` in composite indices of
them, use (tableoid, ctid) pair to ensure edge uniqueness.

This commit has also some bug fixes in `array_position()` family.
Discussion: https://postgr.es/m/CAE+byMupUURYiZ6bKYgMZb9pgV1CYAijJGqWj-90W=nS7uEOeA@mail.gmail.com