### PR TITLE
Debug: Modify logic that changes minHops to a level qual

### DIFF
--- a/src/backend/parser/parse_graph.c
+++ b/src/backend/parser/parse_graph.c
@@ -1792,7 +1792,7 @@ genSelectWithVLR(CypherRel *crel, WithClause *with, bool out)
 	ResTarget  *path;
 	RangeVar   *vlr;
 	SelectStmt *sel;
-	Node	   *lidx;
+	Node	   *lidx = NULL;
 
 	if (crel->direction == CYPHER_REL_DIR_NONE)
 	{
@@ -1816,16 +1816,10 @@ genSelectWithVLR(CypherRel *crel, WithClause *with, bool out)
 		sel->targetList = lappend(sel->targetList, path);
 	sel->fromClause = list_make1(vlr);
 
-	if (indices->lidx == NULL)
+	if (indices->lidx != NULL)
 	{
-		if (indices->uidx == NULL)
-			lidx = NULL;
-		else
-			lidx = indices->uidx;
-	}
-	else
-	{
-		lidx = indices->lidx;
+		if (((A_Const *) indices->lidx)->val.val.ival > 1)
+			lidx = indices->lidx;
 	}
 
 	if (lidx != NULL)


### PR DESCRIPTION
In case of [:elabel*..3]
In the past, A minHops becomes "level >= 3". But "level >= 1" is correct.
Actually, a level qual is only needed if minHops is 2 or more.