### PR TITLE
feat: Remove SPI from CREATE clause.

### DIFF
--- a/src/backend/executor/nodeModifyGraph.c
+++ b/src/backend/executor/nodeModifyGraph.c
@@ -26,6 +26,7 @@
 #include "utils/jsonb.h"
 #include "utils/lsyscache.h"
 #include "utils/memutils.h"
+#include "utils/rel.h"
 #include "utils/typcache.h"
 
 #define SQLCMD_BUFLEN				(NAMEDATALEN + 192)
@@ -34,17 +35,6 @@
  * NOTE: If you add SQLCMD, you should add SqlcmdType for it and use
  *       sqlcmd_cache to run the SQLCMD.
  */
-#define SQLCMD_CREAT_VERTEX \
-	"INSERT INTO \"%s\".\"%s\" VALUES (DEFAULT, $1) RETURNING " \
-	AG_ELEM_LOCAL_ID " AS " AG_ELEM_ID ", " AG_ELEM_PROP_MAP
-#define SQLCMD_VERTEX_NPARAMS		1
-
-#define SQLCMD_CREAT_EDGE \
-	"INSERT INTO \"%s\".\"%s\" VALUES (DEFAULT, $1, $2, $3) RETURNING " \
-	AG_ELEM_LOCAL_ID " AS " AG_ELEM_ID ", " \
-	AG_START_ID ", \"" AG_END_ID "\", " AG_ELEM_PROP_MAP
-#define SQLCMD_EDGE_NPARAMS			3
-
 #define SQLCMD_DEL_ELEM \
 	"DELETE FROM ONLY \"%s\".\"%s\" WHERE " AG_ELEM_LOCAL_ID " = $1"
 #define SQLCMD_DEL_ELEM_NPARAMS		1
@@ -112,6 +102,12 @@ typedef struct SqlcmdEntry
 	SPIPlanPtr	plan;
 } SqlcmdEntry;
 
+typedef struct resultRelTbl
+{
+	Oid laboid;
+	int resultRelIdx;
+} resultRelTbl;
+
 static HTAB *sqlcmd_cache = NULL;
 
 static List *ExecInitGraphPattern(List *pattern, ModifyGraphState *mgstate);
@@ -126,11 +122,8 @@ static Datum createEdge(ModifyGraphState *mgstate, GraphEdge *gedge,
 static TupleTableSlot *createPath(ModifyGraphState *mgstate, GraphPath *path,
 								  TupleTableSlot *slot);
 static Datum findVertex(TupleTableSlot *slot, GraphVertex *node, Graphid *vid);
+static Datum findEdge(TupleTableSlot *slot, GraphEdge *node, Graphid *eid);
 static AttrNumber findAttrInSlotByName(TupleTableSlot *slot, char *name);
-static Datum evalPropMap(ExprState *prop_map, ExprContext *econtext,
-						 TupleTableSlot *slot);
-static Datum copyTupleAsDatum(ExprContext *econtext, HeapTuple tuple,
-							  Oid tupType);
 static void setSlotValueByName(TupleTableSlot *slot, Datum value, char *name);
 static Datum *makeDatumArray(ExprContext *econtext, int len);
 static TupleTableSlot *ExecDeleteGraph(ModifyGraphState *mgstate,
@@ -160,6 +153,7 @@ ModifyGraphState *
 ExecInitModifyGraph(ModifyGraph *mgplan, EState *estate, int eflags)
 {
 	ModifyGraphState *mgstate;
+	ListCell		*lc;
 
 	Assert(!(eflags & (EXEC_FLAG_BACKWARD | EXEC_FLAG_MARK)));
 
@@ -182,6 +176,57 @@ ExecInitModifyGraph(ModifyGraph *mgplan, EState *estate, int eflags)
 	mgstate->sets = ExecInitGraphSets(mgplan->sets, mgstate);
 
 	InitSqlcmdHashTable(estate->es_query_cxt);
+
+	if (mgplan->resultRel)
+	{
+		int		numResultRelations = list_length(mgplan->resultRel);
+		int		resultRelno = 0;
+		ResultRelInfo *resultRelInfos;
+		ResultRelInfo *resultRelInfo;
+
+		resultRelInfos = (ResultRelInfo *)
+			palloc(numResultRelations * sizeof(ResultRelInfo));
+		resultRelInfo = resultRelInfos;
+		foreach(lc, mgplan->resultRel)
+		{
+			Oid			resultrel = lfirst_oid(lc);
+			Relation	resultRelation;
+			RangeTblEntry *rte;
+			resultRelTbl  *reltbl;
+
+			/* Build a minimal RTE for the rel */
+			rte = makeNode(RangeTblEntry);
+			rte->rtekind = RTE_RELATION;
+			rte->relid = resultrel;
+			rte->relkind = RELKIND_RELATION;
+			rte->requiredPerms = ACL_INSERT;
+			rte->lateral = false;
+			rte->inh = false;
+			rte->inFromCl = false;
+			estate->es_range_table = lappend(estate->es_range_table, rte);
+
+			resultRelation = heap_open(resultrel, RowExclusiveLock);
+			InitResultRelInfo(resultRelInfo,
+							  resultRelation,
+							  list_length(estate->es_range_table),
+							  estate->es_instrument);
+
+			ExecOpenIndices(resultRelInfo, false);
+
+			reltbl = palloc(sizeof(resultRelTbl));
+			reltbl->laboid = resultrel;
+			reltbl->resultRelIdx = resultRelno++;
+
+			mgstate->resultRelidx = lappend(mgstate->resultRelidx, reltbl);
+
+			resultRelInfo++;
+		}
+
+		estate->es_result_relations = resultRelInfos;
+		estate->es_num_result_relations = numResultRelations;
+		/* es_result_relation_info is NULL except when within ModifyTable */
+		estate->es_result_relation_info = NULL;
+	}
 
 	return mgstate;
 }
@@ -331,9 +376,6 @@ createPath(ModifyGraphState *mgstate, GraphPath *path, TupleTableSlot *slot)
 	Graphid		prevvid = 0;
 	GraphEdge  *gedge = NULL;
 
-	if (SPI_connect() != SPI_OK_CONNECT)
-		elog(ERROR, "SPI_connect failed");
-
 	if (out)
 	{
 		pathlen = list_length(path->chain);
@@ -393,9 +435,6 @@ createPath(ModifyGraphState *mgstate, GraphPath *path, TupleTableSlot *slot)
 		}
 	}
 
-	if (SPI_finish() != SPI_OK_FINISH)
-		elog(ERROR, "SPI_finish failed");
-
 	/* make a graphpath and set it to the slot */
 	if (out)
 	{
@@ -417,6 +456,37 @@ createPath(ModifyGraphState *mgstate, GraphPath *path, TupleTableSlot *slot)
 	return slot;
 }
 
+static ResultRelInfo *
+getResultRelationInfo(ModifyGraphState *mgstate, char *labelname)
+{
+	EState   *estate = mgstate->ps.state;
+	ListCell *lc;
+	Oid		relOid;
+	Oid		graphOid;
+	int		resultRelIdx = -1;
+
+	graphOid = get_graphname_oid(get_graph_path());
+	relOid   = get_laboid_relid(get_labname_laboid(labelname, graphOid));
+
+	foreach(lc, mgstate->resultRelidx)
+	{
+		resultRelTbl * rrtbl = (resultRelTbl *) lfirst(lc);
+
+		if (rrtbl->laboid == relOid)
+		{
+			resultRelIdx = rrtbl->resultRelIdx;
+			break;
+		}
+	}
+
+	if (resultRelIdx == -1)
+	{
+		elog(ERROR, "could not find target label: %s", labelname);
+	}
+
+	return estate->es_result_relations + resultRelIdx;
+}
+
 /*
  * createVertex - creates a vertex of a given node
  *
@@ -427,69 +497,65 @@ createVertex(ModifyGraphState *mgstate, GraphVertex *gvertex, Graphid *vid,
 			 TupleTableSlot *slot, bool inPath)
 {
 	EState	   *estate = mgstate->ps.state;
-	ExprContext *econtext = mgstate->ps.ps_ExprContext;
-	char	   *label;
-	uint16		labid;
-	Datum		values[SQLCMD_VERTEX_NPARAMS];
-	Oid			argTypes[SQLCMD_VERTEX_NPARAMS] = {JSONBOID};
-	SqlcmdKey	key;
-	SPIPlanPtr	plan;
-	int			ret;
-	TupleDesc	tupDesc;
+	Datum		values[2];
+	bool		isnull[2];
 	HeapTuple	tuple;
-	Datum		vertex = (Datum) NULL;
+	Datum		vertex;
+	ResultRelInfo *resultRelInfo;
+	ResultRelInfo *savedResultRel;
+	TupleTableSlot *insertSlot;
 
-	label = gvertex->label;
-	if (label == NULL)
-		label = AG_VERTEX;
+	Assert(gvertex->label != NULL && gvertex->variable != NULL);
 
-	labid = get_labname_labid(label, get_graphname_oid(get_graph_path()));
+	/*
+	 * Get resultRelationInfo for current label and set to estate.
+	 */
+	resultRelInfo = getResultRelationInfo(mgstate, gvertex->label);
+	savedResultRel = estate->es_result_relation_info;
+	estate->es_result_relation_info = resultRelInfo;
 
-	key.cmdtype = SQLCMD_TYPE_CREAT_VERTEX;
-	key.labid = labid;
-	plan = findPreparedPlan(&key);
-	if (plan == NULL)
-	{
-		char sqlcmd[SQLCMD_BUFLEN];
+	/* Find my vertex slot that be made from result plan. */
+	vertex = findVertex(slot, gvertex, vid);
 
-		snprintf(sqlcmd, SQLCMD_BUFLEN, SQLCMD_CREAT_VERTEX,
-				 get_graph_path(), label);
+	/* Make Heap Tuple for inserting to the heap. */
+	values[0] = GraphidGetDatum(*vid);
+	values[1] = getVertexPropDatum(vertex);
 
-		plan = prepareSqlcmd(&key, sqlcmd, SQLCMD_VERTEX_NPARAMS, argTypes);
-	}
+	memset(isnull, 0, sizeof(bool)*2);
 
-	values[0] = evalPropMap(gvertex->es_prop_map, mgstate->ps.ps_ExprContext,
-							slot);
+	insertSlot = MakeTupleTableSlot();
+	insertSlot->tts_tupleDescriptor = RelationGetDescr(resultRelInfo->ri_RelationDesc);
+	insertSlot->tts_values = values;
+	insertSlot->tts_isnull = isnull;
+	insertSlot->tts_isempty = false;
 
-	ret = SPI_execp(plan, values, NULL, 0);
-	if (ret != SPI_OK_INSERT_RETURNING)
-		elog(ERROR, "CREAT_VERTEX (%s): SPI_execp returned %d", label, ret);
-	if (SPI_processed != 1)
-		elog(ERROR,
-			 "CREAT_VERTEX (%s): only one vertex per execution must be created",
-			 label);
+	tuple = ExecMaterializeSlot(insertSlot);
 
-	tupDesc = SPI_tuptable->tupdesc;
-	tuple = SPI_tuptable->vals[0];
+	/*
+	 * Check the constraints of the tuple
+	 */
+	if (resultRelInfo->ri_RelationDesc->rd_att->constr)
+		ExecConstraints(resultRelInfo, insertSlot, estate);
 
-	if (vid != NULL)
-	{
-		bool isnull;
+	/*
+	 * insert the tuple normally.
+	 *
+	 * Note: heap_insert returns the tid (location) of the new tuple
+	 * in the t_self field.
+	 */
+	(void)heap_insert(resultRelInfo->ri_RelationDesc, tuple,
+					  estate->es_output_cid,
+					  0, NULL);
 
-		Assert(SPI_fnumber(tupDesc, AG_ELEM_ID) == 1);
-		*vid = DatumGetGraphid(SPI_getbinval(tuple, tupDesc, 1, &isnull));
-		Assert(!isnull);
-	}
-
-	/* if this vertex is in the result solely or in some paths, */
-	if (gvertex->variable != NULL || inPath)
-		vertex = copyTupleAsDatum(econtext, tuple, VERTEXOID);
-
-	if (gvertex->variable != NULL)
-		setSlotValueByName(slot, vertex, gvertex->variable);
+	/* insert index entries for tuple */
+	if (resultRelInfo->ri_NumIndices > 0)
+		(void)ExecInsertIndexTuples(insertSlot, &(tuple->t_self),
+									estate, false, NULL, NIL);
 
 	if (mgstate->canSetTag)
-		estate->es_graphwrstats.insertVertex += SPI_processed;
+		estate->es_graphwrstats.insertVertex++;
+
+	estate->es_result_relation_info = savedResultRel;
 
 	return vertex;
 }
@@ -499,58 +565,65 @@ createEdge(ModifyGraphState *mgstate, GraphEdge *gedge, Graphid start,
 		   Graphid end, TupleTableSlot *slot, bool inPath)
 {
 	EState	   *estate = mgstate->ps.state;
-	ExprContext *econtext = mgstate->ps.ps_ExprContext;
-	uint16		labid;
-	Datum		values[SQLCMD_EDGE_NPARAMS];
-	Oid			argTypes[SQLCMD_EDGE_NPARAMS] = {GRAPHIDOID, GRAPHIDOID,
-												 JSONBOID};
-	SqlcmdKey	key;
-	SPIPlanPtr	plan;
-	int			ret;
-	Datum		edge = (Datum) NULL;
+	Datum		values[4];
+	bool		isnull[4];
+	Datum		edge;
+	Graphid		id;
+	ResultRelInfo *resultRelInfo;
+	ResultRelInfo *savedResultRel;
+	TupleTableSlot *insertSlot;
+	HeapTuple	tuple;
 
-	labid = get_labname_labid(gedge->label,
-							  get_graphname_oid(get_graph_path()));
+	/*
+	 * Get resultRelationInfo for current label and set to estate.
+	 */
+	resultRelInfo = getResultRelationInfo(mgstate, gedge->label);
 
-	key.cmdtype = SQLCMD_TYPE_CREAT_EDGE;
-	key.labid = labid;
-	plan = findPreparedPlan(&key);
-	if (plan == NULL)
-	{
-		char sqlcmd[SQLCMD_BUFLEN];
+	savedResultRel = estate->es_result_relation_info;
+	estate->es_result_relation_info = resultRelInfo;
 
-		snprintf(sqlcmd, SQLCMD_BUFLEN, SQLCMD_CREAT_EDGE,
-				 get_graph_path(), gedge->label);
+	edge = findEdge(slot, gedge, &id);
 
-		plan = prepareSqlcmd(&key, sqlcmd, SQLCMD_EDGE_NPARAMS, argTypes);
-	}
+	values[0] = UInt64GetDatum(id);
+	values[1] = GraphidGetDatum(start);
+	values[2] = GraphidGetDatum(end);
+	values[3] = getEdgePropDatum(edge);
 
-	values[0] = GraphidGetDatum(start);
-	values[1] = GraphidGetDatum(end);
-	values[2] = evalPropMap(gedge->es_prop_map, mgstate->ps.ps_ExprContext,
-							slot);
+	memset(isnull, 0, sizeof(bool)*4);
 
-	ret = SPI_execp(plan, values, NULL, 0);
-	if (ret != SPI_OK_INSERT_RETURNING)
-		elog(ERROR, "CREAT_EDGE (%s): SPI_execp returned %d",
-			 gedge->label, ret);
-	if (SPI_processed != 1)
-		elog(ERROR,
-			 "CREAT_EDGE (%s): only one edge per execution must be created",
-			 gedge->label);
+	insertSlot = MakeTupleTableSlot();
+	insertSlot->tts_tupleDescriptor = RelationGetDescr(resultRelInfo->ri_RelationDesc);
+	insertSlot->tts_values = values;
+	insertSlot->tts_isnull = isnull;
+	insertSlot->tts_isempty = false;
 
-	if (gedge->variable != NULL || inPath)
-	{
-		HeapTuple tuple = SPI_tuptable->vals[0];
+	tuple = ExecMaterializeSlot(insertSlot);
 
-		edge = copyTupleAsDatum(econtext, tuple, EDGEOID);
-	}
+	/*
+	 * Check the constraints of the tuple
+	 */
+	if (resultRelInfo->ri_RelationDesc->rd_att->constr)
+		ExecConstraints(resultRelInfo, insertSlot, estate);
 
-	if (gedge->variable != NULL)
-		setSlotValueByName(slot, edge, gedge->variable);
+	/*
+	 * insert the tuple normally.
+	 *
+	 * Note: heap_insert returns the tid (location) of the new tuple
+	 * in the t_self field.
+	 */
+	(void)heap_insert(resultRelInfo->ri_RelationDesc, tuple,
+					  estate->es_output_cid,
+					  0, NULL);
+
+	/* insert index entries for tuple */
+	if (resultRelInfo->ri_NumIndices > 0)
+		(void)ExecInsertIndexTuples(insertSlot, &(tuple->t_self),
+									estate, false, NULL, NIL);
 
 	if (mgstate->canSetTag)
-		estate->es_graphwrstats.insertEdge += SPI_processed;
+		estate->es_graphwrstats.insertEdge++;
+
+	estate->es_result_relation_info = savedResultRel;
 
 	return edge;
 }
@@ -571,6 +644,22 @@ findVertex(TupleTableSlot *slot, GraphVertex *gvertex, Graphid *vid)
 	return vertex;
 }
 
+static Datum
+findEdge(TupleTableSlot *slot, GraphEdge *gedge, Graphid *eid)
+{
+	AttrNumber	attno;
+	Datum		edge;
+
+	attno = findAttrInSlotByName(slot, gedge->variable);
+
+	edge = slot->tts_values[attno - 1];
+
+	if (eid != NULL)
+		*eid = DatumGetGraphid(getEdgeIdDatum(edge));
+
+	return edge;
+}
+
 static AttrNumber
 findAttrInSlotByName(TupleTableSlot *slot, char *name)
 {
@@ -588,62 +677,6 @@ findAttrInSlotByName(TupleTableSlot *slot, char *name)
 			(errcode(ERRCODE_INVALID_NAME),
 			 errmsg("variable \"%s\" does not exist", name)));
 	return InvalidAttrNumber;
-}
-
-static Datum
-evalPropMap(ExprState *prop_map, ExprContext *econtext, TupleTableSlot *slot)
-{
-	Datum		datum;
-	bool		isNull;
-	ExprDoneCond isDone;
-	Jsonb	   *jsonb;
-
-	if (prop_map == NULL)
-		return jsonb_build_object_noargs(NULL);
-
-	if (!(exprType((Node *) prop_map->expr) == JSONBOID))
-		ereport(ERROR,
-				(errcode(ERRCODE_DATATYPE_MISMATCH),
-				 errmsg("property map must be jsonb type")));
-
-	econtext->ecxt_scantuple = slot;
-	datum = ExecEvalExpr(prop_map, econtext, &isNull, &isDone);
-	if (isNull)
-		ereport(ERROR,
-				(errcode(ERRCODE_NULL_VALUE_NOT_ALLOWED),
-				 errmsg("property map cannot be NULL")));
-	if (isDone != ExprSingleResult)
-		ereport(ERROR,
-				(errcode(ERRCODE_SYNTAX_ERROR),
-				 errmsg("single result is expected for property map")));
-
-	jsonb = DatumGetJsonb(datum);
-	if (!JB_ROOT_IS_OBJECT(jsonb))
-		ereport(ERROR,
-				(errcode(ERRCODE_DATATYPE_MISMATCH),
-				 errmsg("jsonb object is expected for property map")));
-
-	return datum;
-}
-
-static Datum
-copyTupleAsDatum(ExprContext *econtext, HeapTuple tuple, Oid tupType)
-{
-	TupleDesc		tupDesc;
-	MemoryContext	oldmctx;
-	Datum			value;
-
-	tupDesc = lookup_rowtype_tupdesc(tupType, -1);
-
-	oldmctx = MemoryContextSwitchTo(econtext->ecxt_per_tuple_memory);
-
-	value = heap_copy_tuple_as_datum(tuple, tupDesc);
-
-	MemoryContextSwitchTo(oldmctx);
-
-	ReleaseTupleDesc(tupDesc);
-
-	return value;
 }
 
 static void

--- a/src/backend/nodes/copyfuncs.c
+++ b/src/backend/nodes/copyfuncs.c
@@ -2765,6 +2765,7 @@ _copyQuery(const Query *from)
 	COPY_SCALAR_FIELD(graph.writeOp);
 	COPY_SCALAR_FIELD(graph.last);
 	COPY_SCALAR_FIELD(graph.detach);
+	COPY_NODE_FIELD(graph.resultRel);
 	COPY_NODE_FIELD(graph.pattern);
 	COPY_NODE_FIELD(graph.exprs);
 

--- a/src/backend/nodes/equalfuncs.c
+++ b/src/backend/nodes/equalfuncs.c
@@ -940,6 +940,7 @@ _equalQuery(const Query *a, const Query *b)
 	COMPARE_SCALAR_FIELD(graph.writeOp);
 	COMPARE_SCALAR_FIELD(graph.last);
 	COMPARE_SCALAR_FIELD(graph.detach);
+	COMPARE_NODE_FIELD(graph.resultRel);
 	COMPARE_NODE_FIELD(graph.pattern);
 	COMPARE_NODE_FIELD(graph.exprs);
 

--- a/src/backend/nodes/outfuncs.c
+++ b/src/backend/nodes/outfuncs.c
@@ -2720,6 +2720,7 @@ _outQuery(StringInfo str, const Query *node)
 	WRITE_ENUM_FIELD(graph.writeOp, GraphWriteOp);
 	WRITE_BOOL_FIELD(graph.last);
 	WRITE_BOOL_FIELD(graph.detach);
+	WRITE_NODE_FIELD(graph.resultRel);
 	WRITE_NODE_FIELD(graph.pattern);
 	WRITE_NODE_FIELD(graph.exprs);
 	WRITE_NODE_FIELD(graph.sets);

--- a/src/backend/nodes/readfuncs.c
+++ b/src/backend/nodes/readfuncs.c
@@ -266,6 +266,7 @@ _readQuery(void)
 	READ_ENUM_FIELD(graph.writeOp, GraphWriteOp);
 	READ_BOOL_FIELD(graph.last);
 	READ_BOOL_FIELD(graph.detach);
+	READ_NODE_FIELD(graph.resultRel);
 	READ_NODE_FIELD(graph.pattern);
 	READ_NODE_FIELD(graph.exprs);
 	READ_NODE_FIELD(graph.sets);

--- a/src/backend/optimizer/plan/createplan.c
+++ b/src/backend/optimizer/plan/createplan.c
@@ -3964,8 +3964,8 @@ create_modifygraph_plan(PlannerInfo *root, ModifyGraphPath *best_path)
 
 	plan = make_modifygraph(root, best_path->canSetTag, best_path->operation,
 							best_path->last, best_path->detach, subplan,
-							best_path->pattern, best_path->exprs,
-							best_path->sets);
+							best_path->resultRel, best_path->pattern,
+							best_path->exprs, best_path->sets);
 
 	copy_generic_path_info(&plan->plan, &best_path->path);
 
@@ -6255,8 +6255,8 @@ is_projection_capable_plan(Plan *plan)
  */
 ModifyGraph *
 make_modifygraph(PlannerInfo *root, bool canSetTag, GraphWriteOp operation,
-				 bool last, bool detach, Plan *subplan, List *pattern,
-				 List *exprs, List *sets)
+				 bool last, bool detach, Plan *subplan, List *resultRel,
+				 List *pattern, List *exprs, List *sets)
 {
 	ModifyGraph *node = makeNode(ModifyGraph);
 
@@ -6265,6 +6265,7 @@ make_modifygraph(PlannerInfo *root, bool canSetTag, GraphWriteOp operation,
 	node->last = last;
 	node->detach = detach;
 	node->subplan = subplan;
+	node->resultRel = resultRel;
 	node->pattern = pattern;
 	node->exprs = exprs;
 	node->sets = sets;

--- a/src/backend/optimizer/plan/planner.c
+++ b/src/backend/optimizer/plan/planner.c
@@ -2063,6 +2063,7 @@ grouping_planner(PlannerInfo *root, bool inheritance_update,
 													parse->graph.last,
 													parse->graph.detach,
 													path,
+													parse->graph.resultRel,
 													parse->graph.pattern,
 													parse->graph.exprs,
 													parse->graph.sets);

--- a/src/backend/optimizer/util/pathnode.c
+++ b/src/backend/optimizer/util/pathnode.c
@@ -3136,7 +3136,8 @@ create_limit_path(PlannerInfo *root, RelOptInfo *rel,
 ModifyGraphPath *
 create_modifygraph_path(PlannerInfo *root, RelOptInfo *rel, bool canSetTag,
 						GraphWriteOp operation, bool last, bool detach,
-						Path *subpath, List *pattern, List *exprs, List *sets)
+						Path *subpath, List *resultRel, List *pattern,
+						List *exprs, List *sets)
 {
 	ModifyGraphPath *pathnode = makeNode(ModifyGraphPath);
 
@@ -3157,6 +3158,7 @@ create_modifygraph_path(PlannerInfo *root, RelOptInfo *rel, bool canSetTag,
 	pathnode->last = last;
 	pathnode->detach = detach;
 	pathnode->subpath = subpath;
+	pathnode->resultRel = resultRel;
 	pathnode->pattern = pattern;
 	pathnode->exprs = exprs;
 	pathnode->sets = sets;

--- a/src/backend/parser/parse_graph.c
+++ b/src/backend/parser/parse_graph.c
@@ -34,7 +34,10 @@
 #include "parser/parse_relation.h"
 #include "parser/parse_target.h"
 #include "parser/parser.h"
+#include "parser/parsetree.h"
+#include "rewrite/rewriteHandler.h"
 #include "utils/builtins.h"
+#include "utils/rel.h"
 #include "utils/syscache.h"
 #include "utils/typcache.h"
 
@@ -116,6 +119,10 @@ static GraphVertex *transformCreateNode(ParseState *pstate, CypherNode *cnode,
 										List **targetList);
 static GraphEdge *transformCreateRel(ParseState *pstate, CypherRel *crel,
 									 List **targetList);
+static Node *makeResultVertex(ParseState *pstate,
+							  char *labname, CypherNode *cnode);
+static Node *makeResultEdge(ParseState *pstate,
+							char *labname, CypherRel *crel);
 
 /* SET/REMOVE */
 static List *transformSetPropList(ParseState *pstate, RangeTblEntry *rte,
@@ -146,6 +153,7 @@ static List *makeTargetListFromJoin(ParseState *pstate, RangeTblEntry *rte);
 static TargetEntry *makeWholeRowTarget(ParseState *pstate, RangeTblEntry *rte);
 static TargetEntry *findTarget(List *targetList, char *resname);
 static Node *findLeftVar(ParseState *pstate, char *varname);
+static Relation setTargetLabel(ParseState *pstate, char *labname);
 
 /* expression - type */
 static Node *makeVertexExpr(ParseState *pstate, RangeTblEntry *rte,
@@ -175,6 +183,7 @@ static RowExpr *makeRowExpr(List *args);
 
 /* utils */
 static char *genUniqueName(void);
+static char *genUniqueVarname(List *targetList);
 
 Query *
 transformCypherSubPattern(ParseState *pstate, CypherSubPattern *subpat)
@@ -584,6 +593,7 @@ transformCypherCreateClause(ParseState *pstate, CypherClause *clause)
 
 	qry->graph.pattern = transformCreatePattern(pstate, pattern,
 												&qry->targetList);
+	qry->graph.resultRel = pstate->p_target_labels;
 	markTargetListOrigins(pstate, qry->targetList);
 
 	qry->rtable = pstate->p_rtable;
@@ -2223,10 +2233,10 @@ static GraphVertex *
 transformCreateNode(ParseState *pstate, CypherNode *cnode, List **targetList)
 {
 	char	   *varname = getCypherName(cnode->variable);
+	char	   *labname = getCypherName(cnode->label);
 	int			varloc = getCypherNameLoc(cnode->variable);
 	TargetEntry *te;
 	bool		create;
-	Node	   *prop_map = NULL;
 	GraphVertex *gvertex;
 
 	te = findTarget(*targetList, varname);
@@ -2241,36 +2251,34 @@ transformCreateNode(ParseState *pstate, CypherNode *cnode, List **targetList)
 
 	if (create)
 	{
-		if (varname != NULL)
-		{
-			Const *dummy;
+		Node	   *vertex;
 
-			/*
-			 * Create a room for a newly created vertex.
-			 * This dummy value will be replaced with the vertex
-			 * in ExecCypherCreate().
-			 */
+		if (labname == NULL)
+			labname = AG_VERTEX;
 
-			dummy = makeNullConst(VERTEXOID, -1, InvalidOid);
-			te = makeTargetEntry((Expr *) dummy,
-								 (AttrNumber) pstate->p_next_resno++,
-								 pstrdup(varname),
-								 false);
+		/* Make vertex expression for result plan */
+		vertex = makeResultVertex(pstate, labname, cnode);
 
-			*targetList = lappend(*targetList, te);
-		}
+		/*
+		 * varname will be used to find vertex that be made from ExecResult.
+		 * so that, varname must be unique in targetList.
+		 */
+		if (varname == NULL)
+			varname = genUniqueVarname(*targetList);
 
-		if (cnode->prop_map != NULL)
-			prop_map = transformPropMap(pstate, cnode->prop_map,
-										EXPR_KIND_INSERT_TARGET);
+		te = makeTargetEntry((Expr *) vertex,
+							 (AttrNumber) pstate->p_next_resno++,
+							 pstrdup(varname),
+							 false);
+
+		*targetList = lappend(*targetList, te);
 	}
 
 	gvertex = makeNode(GraphVertex);
-	if (varname != NULL)
-		gvertex->variable = pstrdup(varname);
-	if (cnode->label != NULL)
-		gvertex->label = pstrdup(getCypherName(cnode->label));
-	gvertex->prop_map = prop_map;
+	gvertex->variable = varname;
+	if (labname != NULL)
+		gvertex->label = pstrdup(labname);
+	gvertex->prop_map = NULL;	/* Not used in CREATE */
 	gvertex->create = create;
 
 	return gvertex;
@@ -2281,6 +2289,8 @@ transformCreateRel(ParseState *pstate, CypherRel *crel, List **targetList)
 {
 	char	   *varname;
 	GraphEdge  *gedge;
+	TargetEntry *te;
+	Node	   *edge;
 
 	if (crel->direction == CYPHER_REL_DIR_NONE)
 		ereport(ERROR,
@@ -2309,17 +2319,24 @@ transformCreateRel(ParseState *pstate, CypherRel *crel, List **targetList)
 				 errmsg("duplicate variable \"%s\"", varname),
 				 parser_errposition(pstate, getCypherNameLoc(crel->variable))));
 
-	if (varname != NULL)
-	{
-		TargetEntry *te;
+	/*
+	 * Make edge expression for result plan.
+	 */
+	edge = makeResultEdge(pstate, getCypherName(linitial(crel->types)), crel);
 
-		te = makeTargetEntry((Expr *) makeNullConst(EDGEOID, -1, InvalidOid),
-							 (AttrNumber) pstate->p_next_resno++,
-							 pstrdup(varname),
-							 false);
+	/*
+	 * varname will be used to find edge that be made from ExecResult.
+	 * so that, varname must be unique in targetList.
+	 */
+	if (varname == NULL)
+		varname = genUniqueVarname(*targetList);
 
-		*targetList = lappend(*targetList, te);
-	}
+	te = makeTargetEntry((Expr *) edge,
+						 (AttrNumber) pstate->p_next_resno++,
+						 pstrdup(varname),
+						 false);
+
+	*targetList = lappend(*targetList, te);
 
 	gedge = makeNode(GraphEdge);
 	switch (crel->direction)
@@ -2334,12 +2351,10 @@ transformCreateRel(ParseState *pstate, CypherRel *crel, List **targetList)
 		default:
 			Assert(!"invalid direction");
 	}
-	if (varname != NULL)
-		gedge->variable = pstrdup(varname);
+
+	gedge->variable = varname;
 	gedge->label = pstrdup(getCypherName(linitial(crel->types)));
-	if (crel->prop_map != NULL)
-		gedge->prop_map = transformPropMap(pstate, crel->prop_map,
-										   EXPR_KIND_INSERT_TARGET);
+	gedge->prop_map = NULL;		/* Not used in CREATE */
 
 	return gedge;
 }
@@ -3099,4 +3114,121 @@ genUniqueName(void)
 	snprintf(data, sizeof(data), "<%010u>", seq++);
 
 	return pstrdup(data);
+}
+
+static Relation
+setTargetLabel(ParseState *pstate, char *labname)
+{
+	RangeVar   *rv;
+	Relation	relation;
+
+	Assert(labname != NULL);
+
+	rv = makeRangeVar(get_graph_path(), labname, -1);
+	relation = parserOpenTable(pstate, rv, RowExclusiveLock);
+
+	pstate->p_target_labels = lappend_oid(pstate->p_target_labels,
+										  RelationGetRelid(relation));
+	return relation;
+}
+
+static Node *
+makeResultVertex(ParseState *pstate, char *labname, CypherNode *cnode)
+{
+	Node 	*id;
+	Node	*prop_map;
+	Node	*vertex_expr;
+	Relation relation;
+
+	/*
+	 * Lock the label and return open relation.
+	 */
+	relation = setTargetLabel(pstate, labname);
+
+	/*
+	 * Properties column has emply jsonb-object, if prop_map is null.
+	 */
+	if(cnode->prop_map == NULL)
+	{
+		A_Const *nullJson = makeNode(A_Const);
+
+		nullJson->val.type = T_String;
+		nullJson->val.val.str = "{}";
+
+		cnode->prop_map = (Node *) nullJson;
+	}
+
+	Assert(attnameAttNum(relation, AG_ELEM_LOCAL_ID, true) == 1);
+
+	id = build_column_default(relation, 1);
+	prop_map = transformPropMap(pstate, cnode->prop_map,
+								EXPR_KIND_INSERT_TARGET);
+
+	vertex_expr = makeTypedRowExpr(list_make2(id, prop_map), VERTEXOID, -1);
+
+	/* not release the lock. */
+	heap_close(relation, NoLock);
+
+	return vertex_expr;
+}
+
+static Node *
+makeResultEdge(ParseState *pstate, char *labname, CypherRel *cnode)
+{
+	Node 	*id;
+	Node	*start;
+	Node	*end;
+	Node	*prop_map;
+	Node	*edge_expr;
+	Relation relation;
+
+	/*
+	 * Lock the label and open relation.
+	 */
+	relation = setTargetLabel(pstate, labname);
+
+	/*
+	 * Properties column has emply jsonb-object, if prop_map is null.
+	 */
+	if(cnode->prop_map == NULL)
+	{
+		A_Const *nullJson = makeNode(A_Const);
+
+		nullJson->val.type = T_String;
+		nullJson->val.val.str = "{}";
+
+		cnode->prop_map = (Node *) nullJson;
+	}
+
+	Assert(attnameAttNum(relation, AG_ELEM_LOCAL_ID, true) == 1);
+
+	id = build_column_default(relation, 1);
+	start = (Node *) makeNullConst(GRAPHIDOID, -1, InvalidOid);
+	end = (Node *)makeNullConst(GRAPHIDOID, -1, InvalidOid);
+	prop_map = transformPropMap(pstate, cnode->prop_map,
+								EXPR_KIND_INSERT_TARGET);
+
+	edge_expr = makeTypedRowExpr(list_make4(id, start, end, prop_map),
+								 EDGEOID, -1);
+
+	/* not release the lock. */
+	heap_close(relation, NoLock);
+
+	return edge_expr;
+}
+
+static char*
+genUniqueVarname(List *targetList)
+{
+	char	ret[20];
+
+	for (;;)
+	{
+		sprintf(ret, "_temp_%u", (uint)random());
+
+		if (findTarget(targetList, ret) == NULL)
+			break;
+	}
+
+	return pstrdup(ret);
 }

--- a/src/backend/utils/adt/graph.c
+++ b/src/backend/utils/adt/graph.c
@@ -707,12 +707,29 @@ getVertexIdDatum(Datum datum)
 	return tuple_getattr(tuphdr, Anum_vertex_id);
 }
 
+
+Datum
+getVertexPropDatum(Datum datum)
+{
+	HeapTupleHeader	tuphdr = DatumGetHeapTupleHeader(datum);
+
+	return tuple_getattr(tuphdr, Anum_vertex_properties);
+}
+
 Datum
 getEdgeIdDatum(Datum datum)
 {
 	HeapTupleHeader	tuphdr = DatumGetHeapTupleHeader(datum);
 
 	return tuple_getattr(tuphdr, Anum_edge_id);
+}
+
+Datum
+getEdgePropDatum(Datum datum)
+{
+	HeapTupleHeader	tuphdr = DatumGetHeapTupleHeader(datum);
+
+	return tuple_getattr(tuphdr, Anum_edge_properties);
 }
 
 void

--- a/src/include/nodes/execnodes.h
+++ b/src/include/nodes/execnodes.h
@@ -2072,7 +2072,6 @@ typedef struct LimitState
 	TupleTableSlot *subSlot;	/* tuple last obtained from subplan */
 } LimitState;
 
-
 /*
  * Graph nodes
  */
@@ -2083,6 +2082,7 @@ typedef struct ModifyGraphState
 	bool		canSetTag;
 	bool		done;
 	PlanState  *subplan;
+	List	   *resultRelidx;	/* list of resultRelation idx */
 	List	   *pattern;		/* graph pattern (list of paths) for CREATE
 								   with `es_prop_map` */
 	List	   *exprs;			/* expression state list for DELETE */

--- a/src/include/nodes/parsenodes.h
+++ b/src/include/nodes/parsenodes.h
@@ -166,6 +166,7 @@ typedef struct Query
 		GraphWriteOp writeOp;
 		bool		last;		/* is this for the last clause? */
 		bool		detach;		/* DETACH DELETE */
+		List	   *resultRel;	/* list for Oid of target labels */
 		List	   *pattern;	/* graph pattern (list of paths) for CREATE */
 		List	   *exprs;		/* expression list for DELETE */
 		List	   *sets;		/* expression list for SET/REMOVE */

--- a/src/include/nodes/plannodes.h
+++ b/src/include/nodes/plannodes.h
@@ -958,6 +958,7 @@ typedef struct ModifyGraph
 	bool		last;			/* is this for the last clause? */
 	bool		detach;			/* DETACH DELETE */
 	Plan	   *subplan;		/* plan producing source data */
+	List	   *resultRel;		/* list for Oid of target labels */
 	List	   *pattern;		/* graph pattern (list of paths) for CREATE */
 	List	   *exprs;			/* expression list for DELETE */
 	List	   *sets;			/* list of GraphSetProp's for SET/REMOVE */

--- a/src/include/nodes/relation.h
+++ b/src/include/nodes/relation.h
@@ -1480,6 +1480,7 @@ typedef struct ModifyGraphPath
 	bool		last;			/* is this for the last clause? */
 	bool		detach;			/* DETACH DELETE */
 	Path	   *subpath;		/* Path producing source data */
+	List	   *resultRel;		/* list for Oid of target labels */
 	List	   *pattern;		/* graph pattern (list of paths) for CREATE */
 	List	   *exprs;			/* expression list for DELETE */
 	List	   *sets;			/* list of GraphSetProp's for SET/REMOVE */

--- a/src/include/optimizer/pathnode.h
+++ b/src/include/optimizer/pathnode.h
@@ -228,8 +228,8 @@ extern LimitPath *create_limit_path(PlannerInfo *root, RelOptInfo *rel,
 				  int64 offset_est, int64 count_est);
 extern ModifyGraphPath *create_modifygraph_path(PlannerInfo *root,
 						RelOptInfo *rel, bool canSetTag, GraphWriteOp operation,
-						bool last, bool detach, Path *subpath, List *pattern,
-						List *exprs, List *sets);
+						bool last, bool detach, Path *subpath, List *resultRel,
+						List *pattern, List *exprs, List *sets);
 
 extern Path *reparameterize_path(PlannerInfo *root, Path *path,
 					Relids required_outer,

--- a/src/include/optimizer/planmain.h
+++ b/src/include/optimizer/planmain.h
@@ -57,7 +57,8 @@ extern bool is_projection_capable_path(Path *path);
 extern bool is_projection_capable_plan(Plan *plan);
 extern ModifyGraph *make_modifygraph(PlannerInfo *root, bool canSetTag,
 									 GraphWriteOp operation, bool last,
-									 bool detach, Plan *subplan, List *pattern,
+									 bool detach, Plan *subplan,
+									 List *resultRel,List *pattern,
 									 List *exprs, List *sets);
 
 /* External use of these functions is deprecated: */

--- a/src/include/parser/parse_node.h
+++ b/src/include/parser/parse_node.h
@@ -169,6 +169,7 @@ struct ParseState
 	void	   *p_ref_hook_state;		/* common passthrough link for above */
 
 	/* graph */
+	List	   *p_target_labels;		/* list for Oid of target labels */
 	Node	   *p_last_colref_elem;		/* for property access */
 	Node	   *p_last_vertex;			/* for VLR */
 	bool		p_opt_match;

--- a/src/include/utils/graph.h
+++ b/src/include/utils/graph.h
@@ -71,7 +71,9 @@ extern Datum vertex_labels(PG_FUNCTION_ARGS);
 
 /* support functions */
 extern Datum getVertexIdDatum(Datum datum);
+extern Datum getVertexPropDatum(Datum datum);
 extern Datum getEdgeIdDatum(Datum datum);
+extern Datum getEdgePropDatum(Datum datum);
 extern void getGraphpathArrays(Datum graphpath, Datum *vertices, Datum *edges);
 extern Datum makeGraphpathDatum(Datum *vertices, int nvertices, Datum *edges,
 								int nedges);

--- a/src/test/regress/expected/cypher_dml.out
+++ b/src/test/regress/expected/cypher_dml.out
@@ -67,10 +67,10 @@ RETURN properties(l) AS lj, properties(j) AS j,
  {"lang": "java"} | {"name": "agens-graph-jdbc", "year": 2016} | {"lang": "c"} | {"name": "agens-graph-odbc", "year": 2016} | {"lang": "en"} | {"name": "agens-graph-docs", "year": 2016}
 (1 row)
 
-CREATE ()-[a:r]->(a);
+CREATE ()-[a:lib]->(a);
 ERROR:  duplicate variable "a"
-LINE 1: CREATE ()-[a:r]->(a);
-                          ^
+LINE 1: CREATE ()-[a:lib]->(a);
+                            ^
 CREATE a=(), (a);
 ERROR:  duplicate variable "a"
 LINE 1: CREATE a=(), (a);
@@ -91,32 +91,32 @@ CREATE ()-[]-();
 ERROR:  only directed relationships are allowed in CREATE
 CREATE ()-[]->();
 ERROR:  only one relationship type is allowed for CREATE
-CREATE ()-[:r|z]->();
+CREATE ()-[:lib|doc]->();
 ERROR:  only one relationship type is allowed for CREATE
-CREATE (a)-[a:r]->();
+CREATE (a)-[a:lib]->();
 ERROR:  duplicate variable "a"
-LINE 1: CREATE (a)-[a:r]->();
+LINE 1: CREATE (a)-[a:lib]->();
                     ^
-CREATE ()-[a:r]->()-[a:z]->();
+CREATE ()-[a:lib]->()-[a:doc]->();
 ERROR:  duplicate variable "a"
-LINE 1: CREATE ()-[a:r]->()-[a:z]->();
-                             ^
-CREATE a=(), ()-[a:z]->();
+LINE 1: CREATE ()-[a:lib]->()-[a:doc]->();
+                               ^
+CREATE a=(), ()-[a:doc]->();
 ERROR:  duplicate variable "a"
-LINE 1: CREATE a=(), ()-[a:z]->();
+LINE 1: CREATE a=(), ()-[a:doc]->();
                          ^
-CREATE ()-[:r =0]->();
+CREATE ()-[:lib =0]->();
 ERROR:  property map must be jsonb type
-LINE 1: CREATE ()-[:r =0]->();
-                       ^
+LINE 1: CREATE ()-[:lib =0]->();
+                         ^
 CREATE (a), a=();
 ERROR:  duplicate variable "a"
 LINE 1: CREATE (a), a=();
                     ^
-CREATE ()-[a:r]->(), a=();
+CREATE ()-[a:lib]->(), a=();
 ERROR:  duplicate variable "a"
-LINE 1: CREATE ()-[a:r]->(), a=();
-                             ^
+LINE 1: CREATE ()-[a:lib]->(), a=();
+                               ^
 CREATE a=(), a=();
 ERROR:  duplicate variable "a"
 LINE 1: CREATE a=(), a=();

--- a/src/test/regress/expected/propertyindex.out
+++ b/src/test/regress/expected/propertyindex.out
@@ -148,7 +148,6 @@ CREATE (:regv1 {'id':'100'});
 CREATE (:regv1 {'id':'100'});
 ERROR:  duplicate key value violates unique constraint "regv1_property_idx"
 DETAIL:  Key ((properties #>> ARRAY['id'::text]))=(100) already exists.
-CONTEXT:  SQL statement "INSERT INTO "g"."regv1" VALUES (DEFAULT, $1) RETURNING id AS id, properties"
 \d g.regv1
                                                     Table "g.regv1"
    Column   |  Type   |                                           Modifiers                                            
@@ -184,7 +183,6 @@ CREATE (:regv1 {'name':{'first':'agens', 'last':'graph'}});
 CREATE (:regv1 {'name':{'first':'agens', 'last':'graph'}});
 ERROR:  duplicate key value violates unique constraint "regv1_property_idx"
 DETAIL:  Key ((properties #>> ARRAY['name'::text, 'first'::text]), (properties #>> ARRAY['name'::text, 'last'::text]))=(agens, graph) already exists.
-CONTEXT:  SQL statement "INSERT INTO "g"."regv1" VALUES (DEFAULT, $1) RETURNING id AS id, properties"
 \d g.regv1
                                                     Table "g.regv1"
    Column   |  Type   |                                           Modifiers                                            

--- a/src/test/regress/sql/cypher_dml.sql
+++ b/src/test/regress/sql/cypher_dml.sql
@@ -49,20 +49,20 @@ RETURN properties(l) AS lj, properties(j) AS j,
        properties((edges(p))[1]) AS lc, properties((vertices(p))[2]) AS c,
        properties(e) AS e, properties(d) AS d;
 
-CREATE ()-[a:r]->(a);
+CREATE ()-[a:lib]->(a);
 CREATE a=(), (a);
 CREATE (a), (a {});
 CREATE (a), (a);
 CREATE (=0);
 CREATE ()-[]-();
 CREATE ()-[]->();
-CREATE ()-[:r|z]->();
-CREATE (a)-[a:r]->();
-CREATE ()-[a:r]->()-[a:z]->();
-CREATE a=(), ()-[a:z]->();
-CREATE ()-[:r =0]->();
+CREATE ()-[:lib|doc]->();
+CREATE (a)-[a:lib]->();
+CREATE ()-[a:lib]->()-[a:doc]->();
+CREATE a=(), ()-[a:doc]->();
+CREATE ()-[:lib =0]->();
 CREATE (a), a=();
-CREATE ()-[a:r]->(), a=();
+CREATE ()-[a:lib]->(), a=();
 CREATE a=(), a=();
 
 --


### PR DESCRIPTION
Previously, vertices and edges were created through an internal SPI call.
To improve performance, we changed to insert vertices and edges directly into the label.