### PR TITLE
Feat: enables index only scan for expr index key

### DIFF
--- a/src/backend/optimizer/path/indxpath.c
+++ b/src/backend/optimizer/path/indxpath.c
@@ -1780,6 +1780,31 @@ find_list_position(Node *node, List **nodelist)
 	return i;
 }
 
+static bool
+match_index_to_expr(Node *clause, IndexOptInfo *index)
+{
+	Node *leftop;
+	Node *rightop;
+	int indexcol;
+
+	if (!is_opclause(clause))
+		return false;
+
+	leftop = get_leftop((Expr *)clause);
+	rightop = get_rightop((Expr *)clause);
+	if (!leftop || !rightop)
+		return false;
+
+	for (indexcol = 0; indexcol < index->ncolumns; indexcol++)
+	{
+		if (index->indexkeys[indexcol] == 0 &&
+				(match_index_to_operand(leftop, indexcol, index) ||
+				 match_index_to_operand(rightop, indexcol, index)))
+			return true;
+	}
+
+	return false;
+}
 
 /*
  * check_index_only
@@ -1825,6 +1850,8 @@ check_index_only(RelOptInfo *rel, IndexOptInfo *index)
 	{
 		RestrictInfo *rinfo = (RestrictInfo *) lfirst(lc);
 
+		if (match_index_to_expr((Node *) rinfo->clause, index))
+			continue;
 		pull_varattnos((Node *) rinfo->clause, rel->relid, &attrs_used);
 	}
 


### PR DESCRIPTION
it works if expr indexes key is in the where clause.

Example:
create index x_idx on x (abs(a), b)
select b from x where abs(a) > 100;      -- create the IOS path
select abs(a) from x where abs(a) > 100; -- do not work