### PR TITLE
feat: Remove SPI from modifygraph.

### DIFF
--- a/src/backend/nodes/copyfuncs.c
+++ b/src/backend/nodes/copyfuncs.c
@@ -2768,6 +2768,7 @@ _copyQuery(const Query *from)
 	COPY_NODE_FIELD(graph.resultRel);
 	COPY_NODE_FIELD(graph.pattern);
 	COPY_NODE_FIELD(graph.exprs);
+	COPY_NODE_FIELD(graph.sets);
 
 	return newnode;
 }
@@ -4511,8 +4512,8 @@ _copyGraphSetProp(const GraphSetProp *from)
 {
 	GraphSetProp *newnode = makeNode(GraphSetProp);
 
+	COPY_STRING_FIELD(variable);
 	COPY_NODE_FIELD(elem);
-	COPY_NODE_FIELD(path);
 	COPY_NODE_FIELD(expr);
 
 	return newnode;

--- a/src/backend/nodes/copyfuncs.c
+++ b/src/backend/nodes/copyfuncs.c
@@ -2765,6 +2765,7 @@ _copyQuery(const Query *from)
 	COPY_SCALAR_FIELD(graph.writeOp);
 	COPY_SCALAR_FIELD(graph.last);
 	COPY_SCALAR_FIELD(graph.detach);
+	COPY_NODE_FIELD(graph.resultRel);
 	COPY_NODE_FIELD(graph.pattern);
 	COPY_NODE_FIELD(graph.exprs);
 
@@ -4488,7 +4489,6 @@ _copyGraphVertex(const GraphVertex *from)
 
 	COPY_STRING_FIELD(variable);
 	COPY_STRING_FIELD(label);
-	COPY_NODE_FIELD(prop_map);
 	COPY_SCALAR_FIELD(create);
 
 	return newnode;
@@ -4502,7 +4502,6 @@ _copyGraphEdge(const GraphEdge *from)
 	COPY_SCALAR_FIELD(direction);
 	COPY_STRING_FIELD(variable);
 	COPY_STRING_FIELD(label);
-	COPY_NODE_FIELD(prop_map);
 
 	return newnode;
 }

--- a/src/backend/nodes/equalfuncs.c
+++ b/src/backend/nodes/equalfuncs.c
@@ -940,6 +940,7 @@ _equalQuery(const Query *a, const Query *b)
 	COMPARE_SCALAR_FIELD(graph.writeOp);
 	COMPARE_SCALAR_FIELD(graph.last);
 	COMPARE_SCALAR_FIELD(graph.detach);
+	COMPARE_NODE_FIELD(graph.resultRel);
 	COMPARE_NODE_FIELD(graph.pattern);
 	COMPARE_NODE_FIELD(graph.exprs);
 
@@ -2887,8 +2888,6 @@ _equalGraphVertex(const GraphVertex *a, const GraphVertex *b)
 {
 	COMPARE_STRING_FIELD(variable);
 	COMPARE_STRING_FIELD(label);
-	COMPARE_NODE_FIELD(prop_map);
-	COMPARE_NODE_FIELD(es_prop_map);
 	COMPARE_SCALAR_FIELD(create);
 
 	return true;
@@ -2900,8 +2899,6 @@ _equalGraphEdge(const GraphEdge *a, const GraphEdge *b)
 	COMPARE_SCALAR_FIELD(direction);
 	COMPARE_STRING_FIELD(variable);
 	COMPARE_STRING_FIELD(label);
-	COMPARE_NODE_FIELD(prop_map);
-	COMPARE_NODE_FIELD(es_prop_map);
 
 	return true;
 }

--- a/src/backend/nodes/equalfuncs.c
+++ b/src/backend/nodes/equalfuncs.c
@@ -943,6 +943,7 @@ _equalQuery(const Query *a, const Query *b)
 	COMPARE_NODE_FIELD(graph.resultRel);
 	COMPARE_NODE_FIELD(graph.pattern);
 	COMPARE_NODE_FIELD(graph.exprs);
+	COMPARE_NODE_FIELD(graph.sets);
 
 	return true;
 }

--- a/src/backend/nodes/outfuncs.c
+++ b/src/backend/nodes/outfuncs.c
@@ -3552,8 +3552,8 @@ _outGraphSetProp(StringInfo str, const GraphSetProp *node)
 {
 	WRITE_NODE_TYPE("GRAPHSETPROP");
 
+	WRITE_STRING_FIELD(variable);
 	WRITE_NODE_FIELD(elem);
-	WRITE_NODE_FIELD(path);
 	WRITE_NODE_FIELD(expr);
 }
 

--- a/src/backend/nodes/outfuncs.c
+++ b/src/backend/nodes/outfuncs.c
@@ -2720,6 +2720,7 @@ _outQuery(StringInfo str, const Query *node)
 	WRITE_ENUM_FIELD(graph.writeOp, GraphWriteOp);
 	WRITE_BOOL_FIELD(graph.last);
 	WRITE_BOOL_FIELD(graph.detach);
+	WRITE_NODE_FIELD(graph.resultRel);
 	WRITE_NODE_FIELD(graph.pattern);
 	WRITE_NODE_FIELD(graph.exprs);
 	WRITE_NODE_FIELD(graph.sets);
@@ -3533,7 +3534,6 @@ _outGraphVertex(StringInfo str, const GraphVertex *node)
 
 	WRITE_STRING_FIELD(variable);
 	WRITE_STRING_FIELD(label);
-	WRITE_NODE_FIELD(prop_map);
 	WRITE_BOOL_FIELD(create);
 }
 
@@ -3545,7 +3545,6 @@ _outGraphEdge(StringInfo str, const GraphEdge *node)
 	WRITE_INT_FIELD(direction);
 	WRITE_STRING_FIELD(variable);
 	WRITE_STRING_FIELD(label);
-	WRITE_NODE_FIELD(prop_map);
 }
 
 static void

--- a/src/backend/nodes/readfuncs.c
+++ b/src/backend/nodes/readfuncs.c
@@ -2299,8 +2299,8 @@ _readGraphSetProp(void)
 {
 	READ_LOCALS(GraphSetProp);
 
+	READ_STRING_FIELD(variable);
 	READ_NODE_FIELD(elem);
-	READ_NODE_FIELD(path);
 	READ_NODE_FIELD(expr);
 
 	READ_DONE();

--- a/src/backend/nodes/readfuncs.c
+++ b/src/backend/nodes/readfuncs.c
@@ -266,6 +266,7 @@ _readQuery(void)
 	READ_ENUM_FIELD(graph.writeOp, GraphWriteOp);
 	READ_BOOL_FIELD(graph.last);
 	READ_BOOL_FIELD(graph.detach);
+	READ_NODE_FIELD(graph.resultRel);
 	READ_NODE_FIELD(graph.pattern);
 	READ_NODE_FIELD(graph.exprs);
 	READ_NODE_FIELD(graph.sets);
@@ -2276,7 +2277,6 @@ _readGraphVertex(void)
 
 	READ_STRING_FIELD(variable);
 	READ_STRING_FIELD(label);
-	READ_NODE_FIELD(prop_map);
 	READ_BOOL_FIELD(create);
 
 	READ_DONE();
@@ -2290,7 +2290,6 @@ _readGraphEdge(void)
 	READ_INT_FIELD(direction);
 	READ_STRING_FIELD(variable);
 	READ_STRING_FIELD(label);
-	READ_NODE_FIELD(prop_map);
 
 	READ_DONE();
 }

--- a/src/backend/optimizer/plan/createplan.c
+++ b/src/backend/optimizer/plan/createplan.c
@@ -3965,8 +3965,8 @@ create_modifygraph_plan(PlannerInfo *root, ModifyGraphPath *best_path)
 
 	plan = make_modifygraph(root, best_path->canSetTag, best_path->operation,
 							best_path->last, best_path->detach, subplan,
-							best_path->pattern, best_path->exprs,
-							best_path->sets);
+							best_path->resultRel, best_path->pattern,
+							best_path->exprs, best_path->sets);
 
 	copy_generic_path_info(&plan->plan, &best_path->path);
 
@@ -6304,8 +6304,8 @@ is_projection_capable_plan(Plan *plan)
  */
 ModifyGraph *
 make_modifygraph(PlannerInfo *root, bool canSetTag, GraphWriteOp operation,
-				 bool last, bool detach, Plan *subplan, List *pattern,
-				 List *exprs, List *sets)
+				 bool last, bool detach, Plan *subplan, List *resultRel,
+				 List *pattern, List *exprs, List *sets)
 {
 	ModifyGraph *node = makeNode(ModifyGraph);
 
@@ -6314,6 +6314,7 @@ make_modifygraph(PlannerInfo *root, bool canSetTag, GraphWriteOp operation,
 	node->last = last;
 	node->detach = detach;
 	node->subplan = subplan;
+	node->resultRel = resultRel;
 	node->pattern = pattern;
 	node->exprs = exprs;
 	node->sets = sets;

--- a/src/backend/optimizer/plan/planner.c
+++ b/src/backend/optimizer/plan/planner.c
@@ -943,7 +943,6 @@ preprocess_graph_sets(PlannerInfo *root, List *sets)
 		GraphSetProp *gsp = lfirst(ls);
 
 		gsp->elem = preprocess_expression(root, gsp->elem, EXPRKIND_TARGET);
-		gsp->path = preprocess_expression(root, gsp->path, EXPRKIND_VALUES);
 		gsp->expr = preprocess_expression(root, gsp->expr, EXPRKIND_VALUES);
 	}
 }

--- a/src/backend/optimizer/plan/planner.c
+++ b/src/backend/optimizer/plan/planner.c
@@ -92,7 +92,6 @@ typedef struct
 /* Local functions */
 static Node *preprocess_expression(PlannerInfo *root, Node *expr, int kind);
 static void preprocess_qual_conditions(PlannerInfo *root, Node *jtnode);
-static void preprocess_graph_pattern(PlannerInfo *root, List *pattern);
 static void preprocess_graph_sets(PlannerInfo *root, List *sets);
 static void inheritance_planner(PlannerInfo *root);
 static void grouping_planner(PlannerInfo *root, bool inheritance_update,
@@ -698,7 +697,6 @@ subquery_planner(PlannerGlobal *glob, Query *parse,
 	}
 
 	/* expressions for graph */
-	preprocess_graph_pattern(root, parse->graph.pattern);
 	parse->graph.exprs = (List *)
 		preprocess_expression(root, (Node *) parse->graph.exprs,
 							  EXPRKIND_TARGET);
@@ -933,42 +931,6 @@ preprocess_qual_conditions(PlannerInfo *root, Node *jtnode)
 	else
 		elog(ERROR, "unrecognized node type: %d",
 			 (int) nodeTag(jtnode));
-}
-
-static void
-preprocess_graph_pattern(PlannerInfo *root, List *pattern)
-{
-	ListCell *lp;
-
-	foreach(lp, pattern)
-	{
-		GraphPath  *p = lfirst(lp);
-		ListCell   *le;
-
-		foreach(le, p->chain)
-		{
-			Node *elem = lfirst(le);
-
-			if (nodeTag(elem) == T_GraphVertex)
-			{
-				GraphVertex *gvertex = (GraphVertex *) elem;
-
-				if (gvertex->create)
-					gvertex->prop_map = preprocess_expression(root,
-															  gvertex->prop_map,
-															  EXPRKIND_VALUES);
-			}
-			else
-			{
-				GraphEdge *gedge = (GraphEdge *) elem;
-
-				Assert(nodeTag(elem) == T_GraphEdge);
-
-				gedge->prop_map = preprocess_expression(root, gedge->prop_map,
-														EXPRKIND_VALUES);
-			}
-		}
-	}
 }
 
 static void
@@ -2063,6 +2025,7 @@ grouping_planner(PlannerInfo *root, bool inheritance_update,
 													parse->graph.last,
 													parse->graph.detach,
 													path,
+													parse->graph.resultRel,
 													parse->graph.pattern,
 													parse->graph.exprs,
 													parse->graph.sets);

--- a/src/backend/optimizer/util/pathnode.c
+++ b/src/backend/optimizer/util/pathnode.c
@@ -3136,7 +3136,8 @@ create_limit_path(PlannerInfo *root, RelOptInfo *rel,
 ModifyGraphPath *
 create_modifygraph_path(PlannerInfo *root, RelOptInfo *rel, bool canSetTag,
 						GraphWriteOp operation, bool last, bool detach,
-						Path *subpath, List *pattern, List *exprs, List *sets)
+						Path *subpath, List *resultRel, List *pattern,
+						List *exprs, List *sets)
 {
 	ModifyGraphPath *pathnode = makeNode(ModifyGraphPath);
 
@@ -3157,6 +3158,7 @@ create_modifygraph_path(PlannerInfo *root, RelOptInfo *rel, bool canSetTag,
 	pathnode->last = last;
 	pathnode->detach = detach;
 	pathnode->subpath = subpath;
+	pathnode->resultRel = resultRel;
 	pathnode->pattern = pattern;
 	pathnode->exprs = exprs;
 	pathnode->sets = sets;

--- a/src/backend/parser/gram.y
+++ b/src/backend/parser/gram.y
@@ -588,7 +588,7 @@ static Node *wrapCypherWithSelect(Node *stmt);
  */
 %token <str>	IDENT FCONST SCONST BCONST XCONST Op
 %token <ival>	ICONST PARAM
-%token			TYPECAST DOT_DOT COLON_EQUALS EQUALS_GREATER
+%token			TYPECAST DOT_DOT COLON_EQUALS EQUALS_GREATER ADD_EQUALS
 %token			LESS_EQUALS GREATER_EQUALS NOT_EQUALS
 
 /*
@@ -709,7 +709,7 @@ static Node *wrapCypherWithSelect(Node *stmt);
 %left		AND
 %right		NOT
 %nonassoc	IS ISNULL NOTNULL	/* IS sets precedence for IS NULL, etc */
-%nonassoc	'<' '>' '=' LESS_EQUALS GREATER_EQUALS NOT_EQUALS
+%nonassoc	'<' '>' '=' LESS_EQUALS GREATER_EQUALS NOT_EQUALS ADD_EQUALS
 %nonassoc	BETWEEN IN_P LIKE ILIKE SIMILAR NOT_LA
 %nonassoc	ESCAPE			/* ESCAPE must be just above LIKE/ILIKE/SIMILAR */
 %left		POSTFIXOP		/* dummy for postfix Op rules */
@@ -15271,6 +15271,15 @@ cypher_setitem:
 					CypherSetProp *n = makeNode(CypherSetProp);
 					n->prop = $1;
 					n->expr = $3;
+					n->add = false;
+					$$ = (Node *) n;
+				}
+			| a_expr ADD_EQUALS a_expr
+				{
+					CypherSetProp *n = makeNode(CypherSetProp);
+					n->prop = $1;
+					n->expr = $3;
+					n->add = true;
 					$$ = (Node *) n;
 				}
 		;
@@ -15288,6 +15297,7 @@ cypher_rmitem:
 					CypherSetProp *n = makeNode(CypherSetProp);
 					n->prop = $1;
 					n->expr = makeNullAConst(-1);
+					n->add = false;
 					$$ = (Node *) n;
 				}
 		;

--- a/src/backend/parser/scan.l
+++ b/src/backend/parser/scan.l
@@ -340,6 +340,7 @@ less_equals		"<="
 greater_equals	">="
 less_greater	"<>"
 not_equals		"!="
+add_equals		"+="
 
 /*
  * "self" is the set of chars that should be returned as single-character
@@ -844,6 +845,11 @@ other			.
 					/* We accept both "<>" and "!=" as meaning NOT_EQUALS */
 					SET_YYLLOC();
 					return NOT_EQUALS;
+				}
+
+{add_equals}	{
+					SET_YYLLOC();
+					return ADD_EQUALS;
 				}
 
 {self}			{

--- a/src/backend/utils/adt/graph.c
+++ b/src/backend/utils/adt/graph.c
@@ -833,6 +833,22 @@ getEdgeIdDatum(Datum datum)
 }
 
 Datum
+getEdgeStartDatum(Datum datum)
+{
+	HeapTupleHeader	tuphdr = DatumGetHeapTupleHeader(datum);
+
+	return tuple_getattr(tuphdr, Anum_edge_start);
+}
+
+Datum
+getEdgeEndDatum(Datum datum)
+{
+	HeapTupleHeader	tuphdr = DatumGetHeapTupleHeader(datum);
+
+	return tuple_getattr(tuphdr, Anum_edge_end);
+}
+
+Datum
 getEdgePropDatum(Datum datum)
 {
 	HeapTupleHeader	tuphdr = DatumGetHeapTupleHeader(datum);
@@ -895,6 +911,50 @@ makeGraphpathDatum(Datum *vertices, int nvertices, Datum *edges, int nedges)
 	ReleaseTupleDesc(tupDesc);
 
 	return HeapTupleGetDatum(graphpath);
+}
+
+Datum
+makeGraphVertexDatum(Datum id, Datum prop)
+{
+	Datum		values[Natts_vertex];
+	bool		isnull[Natts_vertex] = {false, false};
+	TupleDesc	tupDesc;
+	HeapTuple	vertex;
+
+	values[Anum_vertex_id - 1] = id;
+	values[Anum_vertex_properties - 1] = prop;
+
+	tupDesc = lookup_rowtype_tupdesc(VERTEXOID, -1);
+	Assert(tupDesc->natts == Natts_vertex);
+
+	vertex = heap_form_tuple(tupDesc, values, isnull);
+
+	ReleaseTupleDesc(tupDesc);
+
+	return HeapTupleGetDatum(vertex);
+}
+
+Datum
+makeGraphEdgeDatum(Datum id, Datum start, Datum end, Datum prop)
+{
+	Datum		values[Natts_edge];
+	bool		isnull[Natts_edge] = {false, false, false, false};
+	TupleDesc	tupDesc;
+	HeapTuple	edge;
+
+	values[Anum_edge_id - 1] = id;
+	values[Anum_edge_start - 1] = start;
+	values[Anum_edge_end - 1] = end;
+	values[Anum_edge_properties - 1] = prop;
+
+	tupDesc = lookup_rowtype_tupdesc(EDGEOID, -1);
+	Assert(tupDesc->natts == Natts_edge);
+
+	edge = heap_form_tuple(tupDesc, values, isnull);
+
+	ReleaseTupleDesc(tupDesc);
+
+	return HeapTupleGetDatum(edge);
 }
 
 static Datum

--- a/src/backend/utils/adt/graph.c
+++ b/src/backend/utils/adt/graph.c
@@ -815,12 +815,29 @@ getVertexIdDatum(Datum datum)
 	return tuple_getattr(tuphdr, Anum_vertex_id);
 }
 
+
+Datum
+getVertexPropDatum(Datum datum)
+{
+	HeapTupleHeader	tuphdr = DatumGetHeapTupleHeader(datum);
+
+	return tuple_getattr(tuphdr, Anum_vertex_properties);
+}
+
 Datum
 getEdgeIdDatum(Datum datum)
 {
 	HeapTupleHeader	tuphdr = DatumGetHeapTupleHeader(datum);
 
 	return tuple_getattr(tuphdr, Anum_edge_id);
+}
+
+Datum
+getEdgePropDatum(Datum datum)
+{
+	HeapTupleHeader	tuphdr = DatumGetHeapTupleHeader(datum);
+
+	return tuple_getattr(tuphdr, Anum_edge_properties);
 }
 
 void

--- a/src/include/nodes/execnodes.h
+++ b/src/include/nodes/execnodes.h
@@ -2073,7 +2073,6 @@ typedef struct LimitState
 	TupleTableSlot *subSlot;	/* tuple last obtained from subplan */
 } LimitState;
 
-
 /*
  * Graph nodes
  */

--- a/src/include/nodes/graphnodes.h
+++ b/src/include/nodes/graphnodes.h
@@ -42,11 +42,10 @@ typedef struct GraphEdge
 typedef struct GraphSetProp
 {
 	NodeTag		type;
+	char	   *variable;
 	Node	   *elem;			/* expression of vertex/edge */
-	Node	   *path;			/* expression of path (text[]) */
 	Node	   *expr;			/* expression of value */
 	ExprState  *es_elem;
-	ExprState  *es_path;
 	ExprState  *es_expr;
 } GraphSetProp;
 

--- a/src/include/nodes/graphnodes.h
+++ b/src/include/nodes/graphnodes.h
@@ -24,8 +24,6 @@ typedef struct GraphVertex
 	NodeTag		type;
 	char	   *variable;
 	char	   *label;
-	Node	   *prop_map;		/* expression of type jsonb */
-	ExprState  *es_prop_map;	/* expression state of `prop_map` */
 	bool		create;			/* whether this vertex will be created or not */
 } GraphVertex;
 
@@ -39,8 +37,6 @@ typedef struct GraphEdge
 	uint32		direction;		/* bitmask of directions (see above) */
 	char	   *variable;
 	char	   *label;
-	Node	   *prop_map;		/* expression of type jsonb */
-	ExprState  *es_prop_map;	/* expression state of `prop_map` */
 } GraphEdge;
 
 typedef struct GraphSetProp

--- a/src/include/nodes/parsenodes.h
+++ b/src/include/nodes/parsenodes.h
@@ -3364,6 +3364,7 @@ typedef struct CypherSetProp
 	NodeTag		type;
 	Node	   *prop;
 	Node	   *expr;
+	bool		add;
 } CypherSetProp;
 
 #endif   /* PARSENODES_H */

--- a/src/include/nodes/parsenodes.h
+++ b/src/include/nodes/parsenodes.h
@@ -166,6 +166,7 @@ typedef struct Query
 		GraphWriteOp writeOp;
 		bool		last;		/* is this for the last clause? */
 		bool		detach;		/* DETACH DELETE */
+		List	   *resultRel;	/* list for Oid of target labels */
 		List	   *pattern;	/* graph pattern (list of paths) for CREATE */
 		List	   *exprs;		/* expression list for DELETE */
 		List	   *sets;		/* expression list for SET/REMOVE */

--- a/src/include/nodes/plannodes.h
+++ b/src/include/nodes/plannodes.h
@@ -958,6 +958,7 @@ typedef struct ModifyGraph
 	bool		last;			/* is this for the last clause? */
 	bool		detach;			/* DETACH DELETE */
 	Plan	   *subplan;		/* plan producing source data */
+	List	   *resultRel;		/* list for Oid of target labels */
 	List	   *pattern;		/* graph pattern (list of paths) for CREATE */
 	List	   *exprs;			/* expression list for DELETE */
 	List	   *sets;			/* list of GraphSetProp's for SET/REMOVE */

--- a/src/include/nodes/relation.h
+++ b/src/include/nodes/relation.h
@@ -1480,6 +1480,7 @@ typedef struct ModifyGraphPath
 	bool		last;			/* is this for the last clause? */
 	bool		detach;			/* DETACH DELETE */
 	Path	   *subpath;		/* Path producing source data */
+	List	   *resultRel;		/* list for Oid of target labels */
 	List	   *pattern;		/* graph pattern (list of paths) for CREATE */
 	List	   *exprs;			/* expression list for DELETE */
 	List	   *sets;			/* list of GraphSetProp's for SET/REMOVE */

--- a/src/include/optimizer/pathnode.h
+++ b/src/include/optimizer/pathnode.h
@@ -228,8 +228,8 @@ extern LimitPath *create_limit_path(PlannerInfo *root, RelOptInfo *rel,
 				  int64 offset_est, int64 count_est);
 extern ModifyGraphPath *create_modifygraph_path(PlannerInfo *root,
 						RelOptInfo *rel, bool canSetTag, GraphWriteOp operation,
-						bool last, bool detach, Path *subpath, List *pattern,
-						List *exprs, List *sets);
+						bool last, bool detach, Path *subpath, List *resultRel,
+						List *pattern, List *exprs, List *sets);
 
 extern Path *reparameterize_path(PlannerInfo *root, Path *path,
 					Relids required_outer,

--- a/src/include/optimizer/planmain.h
+++ b/src/include/optimizer/planmain.h
@@ -57,7 +57,8 @@ extern bool is_projection_capable_path(Path *path);
 extern bool is_projection_capable_plan(Plan *plan);
 extern ModifyGraph *make_modifygraph(PlannerInfo *root, bool canSetTag,
 									 GraphWriteOp operation, bool last,
-									 bool detach, Plan *subplan, List *pattern,
+									 bool detach, Plan *subplan,
+									 List *resultRel,List *pattern,
 									 List *exprs, List *sets);
 
 /* External use of these functions is deprecated: */

--- a/src/include/parser/parse_node.h
+++ b/src/include/parser/parse_node.h
@@ -180,6 +180,7 @@ struct ParseState
 	Node	   *p_resolved_qual;		/* qual of resolved future vertices */
 	bool		p_is_optional_match;
 	Node	   *p_last_colref_elem;		/* for property access */
+	List	   *p_target_labels;		/* list for Oid of target labels */
 };
 
 /*

--- a/src/include/utils/graph.h
+++ b/src/include/utils/graph.h
@@ -90,10 +90,14 @@ extern Datum vertex_labels(PG_FUNCTION_ARGS);
 extern Datum getVertexIdDatum(Datum datum);
 extern Datum getVertexPropDatum(Datum datum);
 extern Datum getEdgeIdDatum(Datum datum);
+extern Datum getEdgeStartDatum(Datum datum);
+extern Datum getEdgeEndDatum(Datum datum);
 extern Datum getEdgePropDatum(Datum datum);
 extern void getGraphpathArrays(Datum graphpath, Datum *vertices, Datum *edges);
 extern Datum makeGraphpathDatum(Datum *vertices, int nvertices, Datum *edges,
 								int nedges);
+extern Datum makeGraphVertexDatum(Datum id, Datum prop);
+extern Datum makeGraphEdgeDatum(Datum id, Datum start, Datum end, Datum prop);
 
 /* index support - BTree */
 extern Datum btgraphidcmp(PG_FUNCTION_ARGS);

--- a/src/include/utils/graph.h
+++ b/src/include/utils/graph.h
@@ -88,7 +88,9 @@ extern Datum vertex_labels(PG_FUNCTION_ARGS);
 
 /* support functions */
 extern Datum getVertexIdDatum(Datum datum);
+extern Datum getVertexPropDatum(Datum datum);
 extern Datum getEdgeIdDatum(Datum datum);
+extern Datum getEdgePropDatum(Datum datum);
 extern void getGraphpathArrays(Datum graphpath, Datum *vertices, Datum *edges);
 extern Datum makeGraphpathDatum(Datum *vertices, int nvertices, Datum *edges,
 								int nedges);

--- a/src/test/regress/expected/cypher_dml.out
+++ b/src/test/regress/expected/cypher_dml.out
@@ -67,10 +67,10 @@ RETURN properties(l) AS lj, properties(j) AS j,
  {"lang": "java"} | {"name": "agens-graph-jdbc", "year": 2016} | {"lang": "c"} | {"name": "agens-graph-odbc", "year": 2016} | {"lang": "en"} | {"name": "agens-graph-docs", "year": 2016}
 (1 row)
 
-CREATE ()-[a:r]->(a);
+CREATE ()-[a:lib]->(a);
 ERROR:  duplicate variable "a"
-LINE 1: CREATE ()-[a:r]->(a);
-                          ^
+LINE 1: CREATE ()-[a:lib]->(a);
+                            ^
 CREATE a=(), (a);
 ERROR:  duplicate variable "a"
 LINE 1: CREATE a=(), (a);
@@ -91,32 +91,32 @@ CREATE ()-[]-();
 ERROR:  only directed relationships are allowed in CREATE
 CREATE ()-[]->();
 ERROR:  only one relationship type is allowed for CREATE
-CREATE ()-[:r|z]->();
+CREATE ()-[:lib|doc]->();
 ERROR:  only one relationship type is allowed for CREATE
-CREATE (a)-[a:r]->();
+CREATE (a)-[a:lib]->();
 ERROR:  duplicate variable "a"
-LINE 1: CREATE (a)-[a:r]->();
+LINE 1: CREATE (a)-[a:lib]->();
                     ^
-CREATE ()-[a:r]->()-[a:z]->();
+CREATE ()-[a:lib]->()-[a:doc]->();
 ERROR:  duplicate variable "a"
-LINE 1: CREATE ()-[a:r]->()-[a:z]->();
-                             ^
-CREATE a=(), ()-[a:z]->();
+LINE 1: CREATE ()-[a:lib]->()-[a:doc]->();
+                               ^
+CREATE a=(), ()-[a:doc]->();
 ERROR:  duplicate variable "a"
-LINE 1: CREATE a=(), ()-[a:z]->();
+LINE 1: CREATE a=(), ()-[a:doc]->();
                          ^
-CREATE ()-[:r =0]->();
+CREATE ()-[:lib =0]->();
 ERROR:  property map must be jsonb type
-LINE 1: CREATE ()-[:r =0]->();
-                       ^
+LINE 1: CREATE ()-[:lib =0]->();
+                         ^
 CREATE (a), a=();
 ERROR:  duplicate variable "a"
 LINE 1: CREATE (a), a=();
                     ^
-CREATE ()-[a:r]->(), a=();
+CREATE ()-[a:lib]->(), a=();
 ERROR:  duplicate variable "a"
-LINE 1: CREATE ()-[a:r]->(), a=();
-                             ^
+LINE 1: CREATE ()-[a:lib]->(), a=();
+                               ^
 CREATE a=(), a=();
 ERROR:  duplicate variable "a"
 LINE 1: CREATE a=(), a=();

--- a/src/test/regress/expected/cypher_dml.out
+++ b/src/test/regress/expected/cypher_dml.out
@@ -904,15 +904,107 @@ RETURN properties(n) as n, properties(r) as r, properties(m) as m;
  {"name": "somebody"} | {"l": "w"} | {}
 (1 row)
 
+MATCH (a) DETACH DELETE (a);
+-- Strandard SQL 
+CREATE ({age:10});
+MATCH (a {age:10})
+SET a.age = '20', a.age = (a.age::int + 1)::text::jsonb;
+MATCH (a)
+RETURN properties(a);
+ properties  
+-------------
+ {"age": 11}
+(1 row)
+
+MATCH (a) DETACH DELETE (a);
 -- multiple SET
+CREATE ({age:10});
+MATCH (a {age:10})
+SET a.age = '20' SET a.age = (a.age::int + 1)::text::jsonb;
+MATCH (a)
+RETURN properties(a);
+ properties  
+-------------
+ {"age": 21}
+(1 row)
+
+MATCH (a) DETACH DELETE (a);
+CREATE ({'name': 'someone'})-[:rel {'k': 'v'}]->({'name': 'somebody'});
 MATCH (n)-[r]->(m) SET r.l = '"x"' SET r.l = '"y"';
 MATCH (n)-[r]->(m)
 RETURN properties(r) as r;
-     r      
-------------
- {"l": "y"}
+          r           
+----------------------
+ {"k": "v", "l": "y"}
 (1 row)
 
+MATCH (a) DETACH DELETE (a);
+-- addtion operator (+=)
+CREATE ();
+MATCH (a)
+SET a.name += '"new"', a.bit += '"nine"';
+MATCH (a) RETURN a;
+                      a                       
+----------------------------------------------
+ ag_vertex[1.7]{"bit": "nine", "name": "new"}
+(1 row)
+
+MATCH (a)
+SET a.name += '"same"';
+ERROR:  cannot replace existing key
+HINT:  Try using the function jsonb_set to replace key value.
+MATCH (a) RETURN a;
+                      a                       
+----------------------------------------------
+ ag_vertex[1.7]{"bit": "nine", "name": "new"}
+(1 row)
+
+MATCH (a) DETACH DELETE (a);
+-- Remove
+CREATE ({a:'a', b:'b', c:'c'});
+MATCH (a)
+SET a.a = NULL
+REMOVE a.b;
+MATCH (a) RETURN a;
+            a             
+--------------------------
+ ag_vertex[1.8]{"c": "c"}
+(1 row)
+
+MATCH (a)
+SET a = NULL;
+ERROR:  expression must be of type jsonb but unknown
+LINE 2: SET a = NULL;
+                ^
+MATCH (a)
+SET a += NULL;
+ERROR:  expression must be of type jsonb but unknown
+LINE 2: SET a += NULL;
+                 ^
+MATCH (a)
+SET a.c += NULL;
+ERROR:  Invalid Input : '+=' requires not null values.
+LINE 2: SET a.c += NULL;
+                   ^
+MATCH (a) RETURN a;
+            a             
+--------------------------
+ ag_vertex[1.8]{"c": "c"}
+(1 row)
+
+MATCH (a) DETACH DELETE (a);
+-- refering to undefined attributes on SET clause.
+CREATE ({name:'undefined node'});
+CREATE ({age:30});
+MATCH (a) SET a.age = (a.age::int + 10)::text::jsonb;
+MATCH (a) RETURN a;
+                    a                     
+------------------------------------------
+ ag_vertex[1.9]{"name": "undefined node"}
+ ag_vertex[1.10]{"age": 40}
+(2 rows)
+
+MATCH (a) DETACH DELETE (a);
 -- cleanup
 DROP GRAPH p CASCADE;
 NOTICE:  drop cascades to 4 other objects

--- a/src/test/regress/expected/propertyindex.out
+++ b/src/test/regress/expected/propertyindex.out
@@ -145,7 +145,6 @@ CREATE (:regv1 {'id':'100'});
 CREATE (:regv1 {'id':'100'});
 ERROR:  duplicate key value violates unique constraint "regv1_property_idx"
 DETAIL:  Key ((properties #>> ARRAY['id'::text]))=(100) already exists.
-CONTEXT:  SQL statement "INSERT INTO "g"."regv1" VALUES (DEFAULT, $1) RETURNING id AS id, properties"
 \d g.regv1
                                                     Table "g.regv1"
    Column   |  Type   |                                           Modifiers                                            
@@ -180,7 +179,6 @@ CREATE (:regv1 {'name':{'first':'agens', 'last':'graph'}});
 CREATE (:regv1 {'name':{'first':'agens', 'last':'graph'}});
 ERROR:  duplicate key value violates unique constraint "regv1_property_idx"
 DETAIL:  Key ((properties #>> ARRAY['name'::text, 'first'::text]), (properties #>> ARRAY['name'::text, 'last'::text]))=(agens, graph) already exists.
-CONTEXT:  SQL statement "INSERT INTO "g"."regv1" VALUES (DEFAULT, $1) RETURNING id AS id, properties"
 \d g.regv1
                                                     Table "g.regv1"
    Column   |  Type   |                                           Modifiers                                            

--- a/src/test/regress/sql/cypher_dml.sql
+++ b/src/test/regress/sql/cypher_dml.sql
@@ -49,20 +49,20 @@ RETURN properties(l) AS lj, properties(j) AS j,
        properties((edges(p))[1]) AS lc, properties((vertices(p))[2]) AS c,
        properties(e) AS e, properties(d) AS d;
 
-CREATE ()-[a:r]->(a);
+CREATE ()-[a:lib]->(a);
 CREATE a=(), (a);
 CREATE (a), (a {});
 CREATE (a), (a);
 CREATE (=0);
 CREATE ()-[]-();
 CREATE ()-[]->();
-CREATE ()-[:r|z]->();
-CREATE (a)-[a:r]->();
-CREATE ()-[a:r]->()-[a:z]->();
-CREATE a=(), ()-[a:z]->();
-CREATE ()-[:r =0]->();
+CREATE ()-[:lib|doc]->();
+CREATE (a)-[a:lib]->();
+CREATE ()-[a:lib]->()-[a:doc]->();
+CREATE a=(), ()-[a:doc]->();
+CREATE ()-[:lib =0]->();
 CREATE (a), a=();
-CREATE ()-[a:r]->(), a=();
+CREATE ()-[a:lib]->(), a=();
 CREATE a=(), a=();
 
 --

--- a/src/test/regress/sql/cypher_dml.sql
+++ b/src/test/regress/sql/cypher_dml.sql
@@ -371,12 +371,85 @@ MATCH (n)-[r]->(m) REMOVE m.name;
 MATCH (n)-[r]->(m)
 RETURN properties(n) as n, properties(r) as r, properties(m) as m;
 
+MATCH (a) DETACH DELETE (a);
+
+-- Strandard SQL 
+CREATE ({age:10});
+
+MATCH (a {age:10})
+SET a.age = '20', a.age = (a.age::int + 1)::text::jsonb;
+
+MATCH (a)
+RETURN properties(a);
+
+MATCH (a) DETACH DELETE (a);
+
 -- multiple SET
+CREATE ({age:10});
+
+MATCH (a {age:10})
+SET a.age = '20' SET a.age = (a.age::int + 1)::text::jsonb;
+
+MATCH (a)
+RETURN properties(a);
+
+MATCH (a) DETACH DELETE (a);
+
+CREATE ({'name': 'someone'})-[:rel {'k': 'v'}]->({'name': 'somebody'});
 
 MATCH (n)-[r]->(m) SET r.l = '"x"' SET r.l = '"y"';
 
 MATCH (n)-[r]->(m)
 RETURN properties(r) as r;
+
+MATCH (a) DETACH DELETE (a);
+
+-- addtion operator (+=)
+CREATE ();
+
+MATCH (a)
+SET a.name += '"new"', a.bit += '"nine"';
+
+MATCH (a) RETURN a;
+
+MATCH (a)
+SET a.name += '"same"';
+
+MATCH (a) RETURN a;
+
+MATCH (a) DETACH DELETE (a);
+
+-- Remove
+CREATE ({a:'a', b:'b', c:'c'});
+
+MATCH (a)
+SET a.a = NULL
+REMOVE a.b;
+
+MATCH (a) RETURN a;
+
+MATCH (a)
+SET a = NULL;
+
+MATCH (a)
+SET a += NULL;
+
+MATCH (a)
+SET a.c += NULL;
+
+MATCH (a) RETURN a;
+
+MATCH (a) DETACH DELETE (a);
+
+-- refering to undefined attributes on SET clause.
+CREATE ({name:'undefined node'});
+CREATE ({age:30});
+
+MATCH (a) SET a.age = (a.age::int + 10)::text::jsonb;
+
+MATCH (a) RETURN a;
+
+MATCH (a) DETACH DELETE (a);
 
 -- cleanup
 


### PR DESCRIPTION
* Previously, vertices and edges were created through an internal SPI call. To improve performance, we changed to insert vertices and edges directly into the label.

* Improved the SET/REMOVE clause. Call the SPI only once, even if there are multiple changes to one graph element.