### PR TITLE
Fix: add a semicolon to a grammar rule

### DIFF
--- a/src/backend/parser/gram.y
+++ b/src/backend/parser/gram.y
@@ -14738,6 +14738,7 @@ cypher_read_opt_parens:
 cypher_read_with_parens:
 			'(' cypher_read_stmt ')'			{ $$ = $2; }
 			| '(' cypher_read_with_parens ')'	{ $$ = $2; }
+		;
 
 cypher_read_stmt:
 			cypher_read_opt cypher_return


### PR DESCRIPTION
A compile warning occurs on the auto-generated preproc.y
due to incorrect syntax