### PR TITLE
fix: Adjust `max_value` of sequence for local ID

### DIFF
--- a/src/backend/catalog/ag_label.c
+++ b/src/backend/catalog/ag_label.c
@@ -20,6 +20,7 @@
 #include "catalog/indexing.h"
 #include "commands/sequence.h"
 #include "utils/builtins.h"
+#include "utils/graph.h"
 #include "utils/rel.h"
 #include "utils/lsyscache.h"
 #include "utils/syscache.h"
@@ -131,7 +132,7 @@ GetNewLabelId(char *graphname, Oid graphid)
 		if (!labid_exists(graphid, labid))
 			break;
 
-		if (++cnt >= USHRT_MAX)
+		if (++cnt >= GRAPHID_LABID_MAX)
 			ereport(ERROR,
 					(errcode(ERRCODE_PROGRAM_LIMIT_EXCEEDED),
 					 errmsg("no more new labels are available")));

--- a/src/backend/utils/adt/graph.c
+++ b/src/backend/utils/adt/graph.c
@@ -41,8 +41,8 @@
 #define Anum_graphpath_vertices	1
 #define Anum_graphpath_edges	2
 
-#define GRAPHID_FMTSTR			"%u." INT64_FORMAT
-#define GRAPHID_BUFLEN			32	/* "4294967295.18446744073709551615" */
+#define GRAPHID_FMTSTR			"%hu." UINT64_FORMAT
+#define GRAPHID_BUFLEN			32	/* "65535.281474976710655" */
 
 typedef struct LabelOutData {
 	uint16		label_labid;

--- a/src/include/utils/graph.h
+++ b/src/include/utils/graph.h
@@ -31,6 +31,9 @@ typedef uint64 Graphid;
 				 (((uint64) (_locid)) & 0x0000ffffffffffff); \
 	} while (0)
 
+#define GRAPHID_LABID_MAX	USHRT_MAX
+#define GRAPHID_LOCID_MAX	((UINT64CONST(1) << (32 + 16)) - 1)
+
 /* graphid */
 extern Datum graphid(PG_FUNCTION_ARGS);
 extern Datum graphid_in(PG_FUNCTION_ARGS);


### PR DESCRIPTION
Change it from 2^64 - 1 to 2^48 - 1 because the size of local ID is now
6 bytes.