### PR TITLE
chore: Resolve name conflict during create property index

### DIFF
--- a/src/backend/commands/indexcmds.c
+++ b/src/backend/commands/indexcmds.c
@@ -76,7 +76,6 @@ static Oid GetIndexOpClass(List *opclass, Oid attrType,
 static char *ChooseIndexName(const char *tabname, Oid namespaceId,
 				List *colnames, List *exclusionOpNames,
 				bool primary, bool isconstraint);
-static char *ChooseIndexNameAddition(List *colnames);
 static List *ChooseIndexColumnNames(List *indexElems);
 static void RangeVarCallbackForReindexIndex(const RangeVar *relation,
 								Oid relId, Oid oldRelId, void *arg);
@@ -1636,7 +1635,7 @@ ChooseIndexName(const char *tabname, Oid namespaceId,
  * We know that less than NAMEDATALEN characters will actually be used,
  * so we can truncate the result once we've generated that many.
  */
-static char *
+char *
 ChooseIndexNameAddition(List *colnames)
 {
 	char		buf[NAMEDATALEN * 2];

--- a/src/include/commands/defrem.h
+++ b/src/include/commands/defrem.h
@@ -43,6 +43,7 @@ extern bool CheckIndexCompatible(Oid oldId,
 					 List *attributeList,
 					 List *exclusionOpNames);
 extern Oid	GetDefaultOpClass(Oid type_id, Oid am_id);
+extern char *ChooseIndexNameAddition(List *colnames);
 
 /* commands/functioncmds.c */
 extern ObjectAddress CreateFunction(CreateFunctionStmt *stmt, const char *queryString);

--- a/src/test/regress/expected/propertyindex.out
+++ b/src/test/regress/expected/propertyindex.out
@@ -35,11 +35,11 @@ CREATE PROPERTY INDEX ON regv1 ((body.weight::integer / body.height::integer));
  properties | jsonb   | not null default jsonb_build_object()
 Indexes:
     "regv1_pkey" PRIMARY KEY, btree (id)
-    "regv1_property_idx" btree ((properties #>> ARRAY['name'::text]))
-    "regv1_property_idx1" btree ((properties #>> ARRAY['name'::text, 'first'::text]), (properties #>> ARRAY['name'::text, 'last'::text]))
-    "regv1_property_idx2" btree (((properties #>> ARRAY['name'::text, 'first'::text]) || (properties #>> ARRAY['name'::text, 'last'::text])))
-    "regv1_property_idx3" btree (((properties #>> ARRAY['age'::text])::integer))
-    "regv1_property_idx4" btree ((((properties #>> ARRAY['body'::text, 'weight'::text])::integer) / ((properties #>> ARRAY['body'::text, 'height'::text])::integer)))
+    "regv1_age_prop_idx" btree (((properties #>> ARRAY['age'::text])::integer))
+    "regv1_first_last_prop_idx" btree ((properties #>> ARRAY['name'::text, 'first'::text]), (properties #>> ARRAY['name'::text, 'last'::text]))
+    "regv1_height_prop_idx" btree ((((properties #>> ARRAY['body'::text, 'weight'::text])::integer) / ((properties #>> ARRAY['body'::text, 'height'::text])::integer)))
+    "regv1_last_prop_idx" btree (((properties #>> ARRAY['name'::text, 'first'::text]) || (properties #>> ARRAY['name'::text, 'last'::text])))
+    "regv1_name_prop_idx" btree ((properties #>> ARRAY['name'::text]))
 Inherits: g.ag_vertex
 
 DROP VLABEL regv1;
@@ -66,12 +66,12 @@ CREATE PROPERTY INDEX ON regv1 USING gist ((hobby::tsvector));
  properties | jsonb   | not null default jsonb_build_object()
 Indexes:
     "regv1_pkey" PRIMARY KEY, btree (id)
-    "regv1_property_idx" btree ((properties #>> ARRAY['name'::text]))
-    "regv1_property_idx1" btree ((properties #>> ARRAY['name'::text, 'first'::text]))
-    "regv1_property_idx2" hash ((properties #>> ARRAY['name'::text, 'first'::text]))
-    "regv1_property_idx3" brin ((properties #>> ARRAY['name'::text, 'first'::text]))
-    "regv1_property_idx4" gin (((properties #>> ARRAY['self_intro'::text])::tsvector))
-    "regv1_property_idx5" gist (((properties #>> ARRAY['hobby'::text])::tsvector))
+    "regv1_first_prop_idx" btree ((properties #>> ARRAY['name'::text, 'first'::text]))
+    "regv1_first_prop_idx1" hash ((properties #>> ARRAY['name'::text, 'first'::text]))
+    "regv1_first_prop_idx2" brin ((properties #>> ARRAY['name'::text, 'first'::text]))
+    "regv1_hobby_prop_idx" gist (((properties #>> ARRAY['hobby'::text])::tsvector))
+    "regv1_name_prop_idx" btree ((properties #>> ARRAY['name'::text]))
+    "regv1_self_intro_prop_idx" gin (((properties #>> ARRAY['self_intro'::text])::tsvector))
 Inherits: g.ag_vertex
 
 \dGv+ regv1
@@ -84,20 +84,20 @@ Inherits: g.ag_vertex
 Vertex label "g.regv1"
 --
 Property Indexes:
-    "regv1_property_idx" btree (name)
-    "regv1_property_idx1" btree (name.first)
-    "regv1_property_idx2" hash (name.first)
-    "regv1_property_idx3" brin (name.first)
-    "regv1_property_idx4" gin ((self_intro)::tsvector)
-    "regv1_property_idx5" gist ((hobby)::tsvector)
+    "regv1_first_prop_idx" btree (name.first)
+    "regv1_first_prop_idx1" hash (name.first)
+    "regv1_first_prop_idx2" brin (name.first)
+    "regv1_hobby_prop_idx" gist ((hobby)::tsvector)
+    "regv1_name_prop_idx" btree (name)
+    "regv1_self_intro_prop_idx" gin ((self_intro)::tsvector)
 Inherits: g.ag_vertex
 
 DROP VLABEL regv1;
 -- Concurrently build & if not exist
 CREATE VLABEL regv1;
 CREATE PROPERTY INDEX CONCURRENTLY ON regv1 (name.first);
-CREATE PROPERTY INDEX IF NOT EXISTS regv1_property_idx ON regv1 (name.first);
-NOTICE:  relation "regv1_property_idx" already exists, skipping
+CREATE PROPERTY INDEX IF NOT EXISTS regv1_first_prop_idx ON regv1 (name.first);
+NOTICE:  relation "regv1_first_prop_idx" already exists, skipping
 -- Collation & Sort & NULL order
 CREATE PROPERTY INDEX ON regv1 (name.first COLLATE "C" ASC NULLS FIRST);
 -- Tablespace
@@ -113,11 +113,11 @@ CREATE PROPERTY INDEX ON regv1 (name.first) WHERE (name IS NOT NULL);
  properties | jsonb   | not null default jsonb_build_object()
 Indexes:
     "regv1_pkey" PRIMARY KEY, btree (id)
-    "regv1_property_idx" btree ((properties #>> ARRAY['name'::text, 'first'::text]))
-    "regv1_property_idx1" btree ((properties #>> ARRAY['name'::text, 'first'::text]) COLLATE "C" NULLS FIRST)
-    "regv1_property_idx2" btree ((properties #>> ARRAY['name'::text]))
-    "regv1_property_idx3" btree ((properties #>> ARRAY['name'::text, 'first'::text])) WITH (fillfactor='80')
-    "regv1_property_idx4" btree ((properties #>> ARRAY['name'::text, 'first'::text])) WHERE (properties #>> ARRAY['name'::text]) IS NOT NULL
+    "regv1_first_prop_idx" btree ((properties #>> ARRAY['name'::text, 'first'::text]))
+    "regv1_first_prop_idx1" btree ((properties #>> ARRAY['name'::text, 'first'::text]) COLLATE "C" NULLS FIRST)
+    "regv1_first_prop_idx2" btree ((properties #>> ARRAY['name'::text, 'first'::text])) WITH (fillfactor='80')
+    "regv1_first_prop_idx3" btree ((properties #>> ARRAY['name'::text, 'first'::text])) WHERE (properties #>> ARRAY['name'::text]) IS NOT NULL
+    "regv1_name_prop_idx" btree ((properties #>> ARRAY['name'::text]))
 Inherits: g.ag_vertex
 
 \dGv+ regv1
@@ -130,11 +130,11 @@ Inherits: g.ag_vertex
 Vertex label "g.regv1"
 --
 Property Indexes:
-    "regv1_property_idx" btree (name.first)
-    "regv1_property_idx1" btree (name.first COLLATE "C" NULLS FIRST)
-    "regv1_property_idx2" btree (name)
-    "regv1_property_idx3" btree (name.first) WITH (fillfactor='80')
-    "regv1_property_idx4" btree (name.first) WHERE (name) IS NOT NULL
+    "regv1_first_prop_idx" btree (name.first)
+    "regv1_first_prop_idx1" btree (name.first COLLATE "C" NULLS FIRST)
+    "regv1_first_prop_idx2" btree (name.first) WITH (fillfactor='80')
+    "regv1_first_prop_idx3" btree (name.first) WHERE (name) IS NOT NULL
+    "regv1_name_prop_idx" btree (name)
 Inherits: g.ag_vertex
 
 DROP VLABEL regv1;
@@ -143,7 +143,7 @@ CREATE VLABEL regv1;
 CREATE UNIQUE PROPERTY INDEX ON regv1 (id);
 CREATE (:regv1 {'id':'100'});
 CREATE (:regv1 {'id':'100'});
-ERROR:  duplicate key value violates unique constraint "regv1_property_idx"
+ERROR:  duplicate key value violates unique constraint "regv1_id_prop_idx"
 DETAIL:  Key ((properties #>> ARRAY['id'::text]))=(100) already exists.
 CONTEXT:  SQL statement "INSERT INTO "g"."regv1" VALUES (DEFAULT, $1) RETURNING id AS id, properties"
 \d g.regv1
@@ -154,7 +154,7 @@ CONTEXT:  SQL statement "INSERT INTO "g"."regv1" VALUES (DEFAULT, $1) RETURNING 
  properties | jsonb   | not null default jsonb_build_object()
 Indexes:
     "regv1_pkey" PRIMARY KEY, btree (id)
-    "regv1_property_idx" UNIQUE, btree ((properties #>> ARRAY['id'::text]))
+    "regv1_id_prop_idx" UNIQUE, btree ((properties #>> ARRAY['id'::text]))
 Inherits: g.ag_vertex
 
 \dGv+ regv1
@@ -167,7 +167,7 @@ Inherits: g.ag_vertex
 Vertex label "g.regv1"
 --
 Property Indexes:
-    "regv1_property_idx" UNIQUE btree (id)
+    "regv1_id_prop_idx" UNIQUE btree (id)
 Inherits: g.ag_vertex
 
 DROP VLABEL regv1;
@@ -178,7 +178,7 @@ CREATE (:regv1 {'name':{'first':'agens'}});
 CREATE (:regv1 {'name':{'first':'agens'}});
 CREATE (:regv1 {'name':{'first':'agens', 'last':'graph'}});
 CREATE (:regv1 {'name':{'first':'agens', 'last':'graph'}});
-ERROR:  duplicate key value violates unique constraint "regv1_property_idx"
+ERROR:  duplicate key value violates unique constraint "regv1_first_last_prop_idx"
 DETAIL:  Key ((properties #>> ARRAY['name'::text, 'first'::text]), (properties #>> ARRAY['name'::text, 'last'::text]))=(agens, graph) already exists.
 CONTEXT:  SQL statement "INSERT INTO "g"."regv1" VALUES (DEFAULT, $1) RETURNING id AS id, properties"
 \d g.regv1
@@ -189,7 +189,7 @@ CONTEXT:  SQL statement "INSERT INTO "g"."regv1" VALUES (DEFAULT, $1) RETURNING 
  properties | jsonb   | not null default jsonb_build_object()
 Indexes:
     "regv1_pkey" PRIMARY KEY, btree (id)
-    "regv1_property_idx" UNIQUE, btree ((properties #>> ARRAY['name'::text, 'first'::text]), (properties #>> ARRAY['name'::text, 'last'::text]))
+    "regv1_first_last_prop_idx" UNIQUE, btree ((properties #>> ARRAY['name'::text, 'first'::text]), (properties #>> ARRAY['name'::text, 'last'::text]))
 Inherits: g.ag_vertex
 
 \dGv+ regv1
@@ -202,7 +202,7 @@ Inherits: g.ag_vertex
 Vertex label "g.regv1"
 --
 Property Indexes:
-    "regv1_property_idx" UNIQUE btree (name.first, name.last)
+    "regv1_first_last_prop_idx" UNIQUE btree (name.first, name.last)
 Inherits: g.ag_vertex
 
 DROP VLABEL regv1;

--- a/src/test/regress/sql/propertyindex.sql
+++ b/src/test/regress/sql/propertyindex.sql
@@ -47,7 +47,7 @@ DROP VLABEL regv1;
 CREATE VLABEL regv1;
 
 CREATE PROPERTY INDEX CONCURRENTLY ON regv1 (name.first);
-CREATE PROPERTY INDEX IF NOT EXISTS regv1_property_idx ON regv1 (name.first);
+CREATE PROPERTY INDEX IF NOT EXISTS regv1_first_prop_idx ON regv1 (name.first);
 
 -- Collation & Sort & NULL order
 CREATE PROPERTY INDEX ON regv1 (name.first COLLATE "C" ASC NULLS FIRST);


### PR DESCRIPTION
This is work around solution. But it's okay in most case.
And it's not critical even if it fails.