### PR TITLE
fix: Manage materialized slots for vertex/edge insertion

### DIFF
--- a/src/include/nodes/execnodes.h
+++ b/src/include/nodes/execnodes.h
@@ -2084,6 +2084,7 @@ typedef struct ModifyGraphState
 	bool		canSetTag;
 	bool		done;
 	PlanState  *subplan;
+	TupleTableSlot *elemTupleSlot;	/* to insert vertex/edge */
 	List	   *pattern;		/* graph pattern (list of paths) for CREATE
 								   with `es_prop_map` */
 	List	   *exprs;			/* expression state list for DELETE */


### PR DESCRIPTION
The materialized slots are allocated from `es_query_cxt` so they must be
cleared for each vertex/edge insertion.

Closes #145