### PR TITLE
fix: ModifyGraph uses its own variable for result relations

### DIFF
--- a/src/include/nodes/execnodes.h
+++ b/src/include/nodes/execnodes.h
@@ -2086,6 +2086,8 @@ typedef struct ModifyGraphState
 	bool		done;
 	PlanState  *subplan;
 	TupleTableSlot *elemTupleSlot;	/* to insert vertex/edge */
+	ResultRelInfo *resultRelations;
+	int			numResultRelations;
 	List	   *pattern;		/* graph pattern (list of paths) for CREATE
 								   with `es_prop_map` */
 	List	   *exprs;			/* expression state list for DELETE */


### PR DESCRIPTION
ModifyGraph now uses `resultRelations` instead of `es_result_relations`
to allow multiple ModifyGraph can be executed in the same plan.