### PR TITLE
chore: Allow ALTER TABLE on graph label for superuser

### DIFF
--- a/src/backend/parser/parse_utilcmd.c
+++ b/src/backend/parser/parse_utilcmd.c
@@ -2497,10 +2497,10 @@ transformAlterTableStmt(Oid relid, AlterTableStmt *stmt,
 	AlterTableCmd *newcmd;
 	RangeTblEntry *rte;
 
-	if (OidIsValid(get_relid_laboid(relid)) &&
-		stmt->relkind != OBJECT_VLABEL &&
-		stmt->relkind != OBJECT_ELABEL)
-		elog(ERROR, "cannot ALTER TABLE on graph label");
+	if (!superuser_arg(GetUserId()) &&
+		OidIsValid(get_relid_laboid(relid)) &&
+		stmt->relkind == OBJECT_TABLE)
+		elog(ERROR, "only superuser can ALTER TABLE on graph label");
 
 	/*
 	 * We must not scribble on the passed-in AlterTableStmt, so copy it. (This

--- a/src/test/regress/expected/sql_restriction.out
+++ b/src/test/regress/expected/sql_restriction.out
@@ -21,16 +21,21 @@ ERROR:  cannot create table in graph schema
 CREATE TABLE t (i int) INHERITS (g.ag_vertex);
 ERROR:  invalid parent, table cannot inherit label
 --
--- ALTER TABLE
---
+-- ALTER TABLE 
+-- allowed to super user
+GRANT ALL ON DATABASE regression TO tmp;
+SET ROLE tmp;
+CREATE GRAPH t;
+SET graph_path=t;
 CREATE VLABEL v;
-ALTER TABLE g.v ADD COLUMN tmp int;
-ERROR:  cannot ALTER TABLE on graph label
+ALTER TABLE t.v ADD COLUMN tmp int;
+ERROR:  only superuser can ALTER TABLE on graph label
+RESET ROLE;
+SET graph_path=g;
+CREATE VLABEL v;
 ALTER TABLE g.v RENAME TO e;
 ERROR:  cannot rename table "v"
 HINT:  Use rename label instead
-ALTER TABLE g.v OWNER TO tmp;
-ERROR:  cannot ALTER TABLE on graph label
 --
 -- TRIGGER
 --
@@ -54,6 +59,13 @@ ERROR:  DML query to graph objcts is not allowed
 DELETE FROM g.v;
 ERROR:  DML query to graph objcts is not allowed
 -- cleanup
+REVOKE ALL ON DATABASE regression FROM tmp;
+DROP GRAPH t CASCADE;
+NOTICE:  drop cascades to 4 other objects
+DETAIL:  drop cascades to sequence t.ag_label_seq
+drop cascades to label ag_vertex
+drop cascades to label ag_edge
+drop cascades to label v
 DROP ROLE tmp;
 DROP GRAPH g CASCADE;
 NOTICE:  drop cascades to 5 other objects

--- a/src/test/regress/sql/sql_restriction.sql
+++ b/src/test/regress/sql/sql_restriction.sql
@@ -20,14 +20,21 @@ CREATE TABLE g.t (i int);
 CREATE TABLE t (i int) INHERITS (g.ag_vertex);
 
 --
--- ALTER TABLE
---
+-- ALTER TABLE 
+-- allowed to super user
+GRANT ALL ON DATABASE regression TO tmp;
+SET ROLE tmp;
+CREATE GRAPH t;
+SET graph_path=t;
 
 CREATE VLABEL v;
+ALTER TABLE t.v ADD COLUMN tmp int;
 
-ALTER TABLE g.v ADD COLUMN tmp int;
+RESET ROLE;
+SET graph_path=g;
+
+CREATE VLABEL v;
 ALTER TABLE g.v RENAME TO e;
-ALTER TABLE g.v OWNER TO tmp;
 
 --
 -- TRIGGER
@@ -50,5 +57,7 @@ UPDATE g.v SET properties='{"update":"impossible"}' WHERE id = '1234.56';
 DELETE FROM g.v;
 
 -- cleanup
+REVOKE ALL ON DATABASE regression FROM tmp;
+DROP GRAPH t CASCADE;
 DROP ROLE tmp;
 DROP GRAPH g CASCADE;


### PR DESCRIPTION
RENAME TABLE on graph label is still not allowed.