### PR TITLE
[WIP] Add binary in/out for graphid

### DIFF
--- a/src/backend/utils/adt/graph.c
+++ b/src/backend/utils/adt/graph.c
@@ -19,6 +19,8 @@
 #include "catalog/pg_type.h"
 #include "executor/spi.h"
 #include "funcapi.h"
+#include "libpq/libpq.h"
+#include "libpq/pqformat.h"
 #include "utils/array.h"
 #include "utils/arrayaccess.h"
 #include "utils/builtins.h"
@@ -129,6 +131,25 @@ graphid_out(PG_FUNCTION_ARGS)
 			 GraphidGetLabid(id), GraphidGetLocid(id));
 
 	PG_RETURN_CSTRING(buf);
+}
+
+Datum
+graphid_recv(PG_FUNCTION_ARGS)
+{
+	StringInfo	buf = (StringInfo) PG_GETARG_POINTER(0);
+
+	PG_RETURN_GRAPHID((Graphid) pq_getmsgint64(buf));
+}
+
+Datum
+graphid_send(PG_FUNCTION_ARGS)
+{
+	Graphid		arg1 = PG_GETARG_GRAPHID(0);
+	StringInfoData buf;
+
+	pq_begintypsend(&buf);
+	pq_sendint64(&buf, arg1);
+	PG_RETURN_BYTEA_P(pq_endtypsend(&buf));
 }
 
 static void

--- a/src/include/catalog/pg_proc.h
+++ b/src/include/catalog/pg_proc.h
@@ -5332,6 +5332,10 @@ DATA(insert OID = 7003 ( graphid_in		PGNSP PGUID 12 1 0 0 0 f f f f t f i s 1 0 
 DESCR("I/O");
 DATA(insert OID = 7004 ( graphid_out	PGNSP PGUID 12 1 0 0 0 f f f f t f i s 1 0 2275 "7002" _null_ _null_ _null_ _null_ _null_ graphid_out _null_ _null_ _null_ ));
 DESCR("I/O");
+DATA(insert OID = 7005 ( graphid_recv	 PGNSP PGUID 12 1 0 0 0 f f f f t f i s 1 0 114 "2281" _null_ _null_ _null_ _null_ _null_ graphid_recv _null_ _null_ _null_ ));
+DESCR("I/O");
+DATA(insert OID = 7006 ( graphid_send	 PGNSP PGUID 12 1 0 0 0 f f f f t f i s 1 0 17 "114" _null_ _null_ _null_ _null_ _null_ graphid_send _null_ _null_ _null_ ));
+DESCR("I/O");
 DATA(insert OID = 7007 ( graphid_labid	PGNSP PGUID 12 1 0 0 0 f f f f t f i s 1 0 23 "7002" _null_ _null_ _null_ _null_ _null_ graphid_labid _null_ _null_ _null_ ));
 DATA(insert OID = 7008 ( graphid_locid	PGNSP PGUID 12 1 0 0 0 f f f f t f i s 1 0 20 "7002" _null_ _null_ _null_ _null_ _null_ graphid_locid _null_ _null_ _null_ ));
 DATA(insert OID = 7009 ( graph_labid	PGNSP PGUID 12 1 0 0 0 f f f f t f s s 1 0 23 "2275" _null_ _null_ _null_ _null_ _null_ graph_labid _null_ _null_ _null_ ));

--- a/src/include/catalog/pg_proc.h
+++ b/src/include/catalog/pg_proc.h
@@ -5332,9 +5332,9 @@ DATA(insert OID = 7003 ( graphid_in		PGNSP PGUID 12 1 0 0 0 f f f f t f i s 1 0 
 DESCR("I/O");
 DATA(insert OID = 7004 ( graphid_out	PGNSP PGUID 12 1 0 0 0 f f f f t f i s 1 0 2275 "7002" _null_ _null_ _null_ _null_ _null_ graphid_out _null_ _null_ _null_ ));
 DESCR("I/O");
-DATA(insert OID = 7005 ( graphid_recv	 PGNSP PGUID 12 1 0 0 0 f f f f t f i s 1 0 114 "2281" _null_ _null_ _null_ _null_ _null_ graphid_recv _null_ _null_ _null_ ));
+DATA(insert OID = 7005 ( graphid_recv	 PGNSP PGUID 12 1 0 0 0 f f f f t f i s 1 0 7002 "2281" _null_ _null_ _null_ _null_ _null_ graphid_recv _null_ _null_ _null_ ));
 DESCR("I/O");
-DATA(insert OID = 7006 ( graphid_send	 PGNSP PGUID 12 1 0 0 0 f f f f t f i s 1 0 17 "114" _null_ _null_ _null_ _null_ _null_ graphid_send _null_ _null_ _null_ ));
+DATA(insert OID = 7006 ( graphid_send	 PGNSP PGUID 12 1 0 0 0 f f f f t f i s 1 0 17 "7002" _null_ _null_ _null_ _null_ _null_ graphid_send _null_ _null_ _null_ ));
 DESCR("I/O");
 DATA(insert OID = 7007 ( graphid_labid	PGNSP PGUID 12 1 0 0 0 f f f f t f i s 1 0 23 "7002" _null_ _null_ _null_ _null_ _null_ graphid_labid _null_ _null_ _null_ ));
 DATA(insert OID = 7008 ( graphid_locid	PGNSP PGUID 12 1 0 0 0 f f f f t f i s 1 0 20 "7002" _null_ _null_ _null_ _null_ _null_ graphid_locid _null_ _null_ _null_ ));

--- a/src/include/catalog/pg_type.h
+++ b/src/include/catalog/pg_type.h
@@ -653,7 +653,7 @@ DATA(insert OID = 3927 ( _int8range		PGNSP PGUID  -1 f b A f t \054 0 3926 0 arr
 
 /* types for graphs */
 DATA(insert OID = 7001 ( _graphid	PGNSP PGUID -1 f b A f t \054 0 7002 0 array_in array_out array_recv array_send - - array_typanalyze d x f 0 -1 0 0 _null_ _null_ _null_ ));
-DATA(insert OID = 7002 ( graphid	PGNSP PGUID 8 FLOAT8PASSBYVAL b U f t \054 0 0 7001 graphid_in graphid_out - - - - - d p f 0 -1 0 0 _null_ _null_ _null_ ));
+DATA(insert OID = 7002 ( graphid	PGNSP PGUID 8 FLOAT8PASSBYVAL b U f t \054 0 0 7001 graphid_in graphid_out graphid_recv graphid_send - - - d p f 0 -1 0 0 _null_ _null_ _null_ ));
 DESCR("unique ID of vertex/edge");
 #define GRAPHIDOID		7002
 DATA(insert OID = 7011 ( _vertex	PGNSP PGUID -1 f b A f t \054 0 7012 0 array_in _vertex_out array_recv array_send - - array_typanalyze d x f 0 -1 0 0 _null_ _null_ _null_ ));

--- a/src/include/utils/graph.h
+++ b/src/include/utils/graph.h
@@ -38,6 +38,8 @@ typedef uint64 Graphid;
 extern Datum graphid(PG_FUNCTION_ARGS);
 extern Datum graphid_in(PG_FUNCTION_ARGS);
 extern Datum graphid_out(PG_FUNCTION_ARGS);
+extern Datum graphid_recv(PG_FUNCTION_ARGS);
+extern Datum graphid_send(PG_FUNCTION_ARGS);
 extern Datum graphid_labid(PG_FUNCTION_ARGS);
 extern Datum graphid_locid(PG_FUNCTION_ARGS);
 extern Datum graph_labid(PG_FUNCTION_ARGS);


### PR DESCRIPTION
Hello, 

This pull request adds binary in/out functions for the Graphid type. It addresses issue #115.
 
I was not sure how to add tests for this within the project, but I've tested both input and output manually by connecting via the Npgsql driver and using graphid as a parameter and return type for functions and queries. This id is sent/received as an 8 byte over the wire rather than breaking it apart into label + location id (2 + 8). I'm not sure if this is the right strategy. 

In pg_proc.h I'm not sure what all the columns mean. Please advise if I've got those wrong.

Thanks,
John