### PR TITLE
Add: ACL logic to the CypherDelete

### DIFF
--- a/src/backend/executor/execCypherDelete.c
+++ b/src/backend/executor/execCypherDelete.c
@@ -18,6 +18,7 @@
 #include "utils/lsyscache.h"
 #include "access/heapam.h"
 #include "pgstat.h"
+#include "utils/acl.h"
 #include "utils/arrayaccess.h"
 #include "access/xact.h"
 #include "commands/trigger.h"
@@ -58,6 +59,8 @@ ExecDeleteGraph(ModifyGraphState *mgstate, TupleTableSlot *slot)
 		Datum		elem;
 		bool		isNull;
 		AttrNumber	attno = findAttrInSlotByName(slot, gde->variable);
+		AclResult	aclresult;
+		char	   *graphpath_name;
 
 		type = exprType((Node *) gde->elem);
 		if (!(type == VERTEXOID || type == EDGEOID ||
@@ -72,6 +75,13 @@ ExecDeleteGraph(ModifyGraphState *mgstate, TupleTableSlot *slot)
 		{
 			continue;
 		}
+
+		graphpath_name = get_graphid_graphname(get_graph_path_oid());
+
+		aclresult = pg_namespace_aclcheck(get_namespace_oid(graphpath_name, true),
+										  GetUserId(), ACL_DELETE);
+		if (aclresult != ACLCHECK_OK)
+			aclcheck_error(aclresult, OBJECT_SCHEMA, graphpath_name);
 
 		/*
 		 * NOTE: After all the graph elements to be removed are collected,

--- a/src/test/regress/expected/cypher_privileges.out
+++ b/src/test/regress/expected/cypher_privileges.out
@@ -1,0 +1,57 @@
+--
+-- Test access privileges for graph element
+--
+-- Suppress NOTICE messages when users/groups don't exist
+SET client_min_messages TO 'warning';
+-- drop, if exists
+DROP GRAPH IF EXISTS graph_priv_test CASCADE;
+-- create, set graph
+CREATE GRAPH graph_priv_test;
+SET graph_path = graph_priv_test;
+-- create user
+CREATE USER readonly_user LOGIN PASSWORD 'ru';
+CREATE USER new_user LOGIN PASSWORD 'nu';
+-- create role
+CREATE ROLE readonly LOGIN;
+GRANT SELECT ON ALL SEQUENCES IN SCHEMA graph_priv_test TO readonly;
+GRANT SELECT ON ALL TABLES IN SCHEMA graph_priv_test TO readonly;
+GRANT USAGE ON SCHEMA graph_priv_test TO readonly;
+-- grant a role to user
+GRANT readonly TO "readonly_user";
+-- give select priv to user
+ALTER DEFAULT PRIVILEGES IN SCHEMA graph_priv_test GRANT SELECT ON SEQUENCES TO group readonly;
+ALTER DEFAULT PRIVILEGES IN SCHEMA graph_priv_test GRANT SELECT ON TABLES TO group readonly;
+ALTER DEFAULT PRIVILEGES FOR USER new_user GRANT SELECT ON TABLES TO group readonly;
+-- create vertices, by superuser
+create (:v1{'property':'1'});
+create (:v1{'property':'2'});
+create (:v1{'property':'3'});
+create (:v1{'property':'4'});
+create (:v1{'property':'a'});
+create (:v1{'property':'b'});
+create (:v1{'property':'c'});
+create (:v1{'property':'d'});
+-- create edges, by superuser
+match (n1:v1 {'property':'1'} ), (n2:v1 {'property':'a'}) create (n1)-[n3:e1 {property:'1a'}]->(n2);
+match (n1:v1 {'property':'2'} ), (n2:v1 {'property':'b'}) create (n1)-[n3:e1 {property:'2b'}]->(n2);
+match (n1:v1 {'property':'3'} ), (n2:v1 {'property':'c'}) create (n1)-[n3:e1 {property:'3c'}]->(n2);
+match (n1:v1 {'property':'4'} ), (n2:v1 {'property':'d'}) create (n1)-[n3:e1 {property:'4d'}]->(n2);
+-- delete vertex, by readonly user
+SET SESSION AUTHORIZATION readonly_user;
+MATCH (n{'property':'1'}) WHERE NOT EXISTS ((n)-[*1]-()) return n;
+            n             
+--------------------------
+ v1[3.1]{"property": "1"}
+(1 row)
+
+MATCH (n{'property':'1'}) WHERE NOT EXISTS ((n)-[*1]-()) delete n; -- #624 issue
+ERROR:  permission denied for schema graph_priv_test
+MATCH (n{'property':'1'}) WHERE NOT EXISTS ((n)-[*1]-()) return n;
+            n             
+--------------------------
+ v1[3.1]{"property": "1"}
+(1 row)
+
+-- clear all
+RESET SESSION AUTHORIZATION;
+DROP GRAPH IF EXISTS graph_priv_test CASCADE;

--- a/src/test/regress/parallel_schedule
+++ b/src/test/regress/parallel_schedule
@@ -145,6 +145,9 @@ test: cypher_dml cypher_dml2 cypher_shortestpath cypher_eager graphid
 # run cypher expr test
 test: cypher_expr
 
+# run cypher priviledge test
+test: cypher_privileges
+
 # run graphmeta
 test: graphmeta
 

--- a/src/test/regress/sql/cypher_privileges.sql
+++ b/src/test/regress/sql/cypher_privileges.sql
@@ -1,0 +1,68 @@
+--
+-- Test access privileges for graph element
+--
+
+-- Suppress NOTICE messages when users/groups don't exist
+
+SET client_min_messages TO 'warning';
+
+-- drop, if exists
+
+DROP GRAPH IF EXISTS graph_priv_test CASCADE;
+
+-- create, set graph
+
+CREATE GRAPH graph_priv_test;
+SET graph_path = graph_priv_test;
+
+-- create user
+
+CREATE USER readonly_user LOGIN PASSWORD 'ru';
+CREATE USER new_user LOGIN PASSWORD 'nu';
+
+-- create role
+
+CREATE ROLE readonly LOGIN;
+GRANT SELECT ON ALL SEQUENCES IN SCHEMA graph_priv_test TO readonly;
+GRANT SELECT ON ALL TABLES IN SCHEMA graph_priv_test TO readonly;
+GRANT USAGE ON SCHEMA graph_priv_test TO readonly;
+
+-- grant a role to user
+
+GRANT readonly TO "readonly_user";
+
+-- give select priv to user
+
+ALTER DEFAULT PRIVILEGES IN SCHEMA graph_priv_test GRANT SELECT ON SEQUENCES TO group readonly;
+ALTER DEFAULT PRIVILEGES IN SCHEMA graph_priv_test GRANT SELECT ON TABLES TO group readonly;
+ALTER DEFAULT PRIVILEGES FOR USER new_user GRANT SELECT ON TABLES TO group readonly;
+
+-- create vertices, by superuser
+
+create (:v1{'property':'1'});
+create (:v1{'property':'2'});
+create (:v1{'property':'3'});
+create (:v1{'property':'4'});
+create (:v1{'property':'a'});
+create (:v1{'property':'b'});
+create (:v1{'property':'c'});
+create (:v1{'property':'d'});
+
+-- create edges, by superuser
+
+match (n1:v1 {'property':'1'} ), (n2:v1 {'property':'a'}) create (n1)-[n3:e1 {property:'1a'}]->(n2);
+match (n1:v1 {'property':'2'} ), (n2:v1 {'property':'b'}) create (n1)-[n3:e1 {property:'2b'}]->(n2);
+match (n1:v1 {'property':'3'} ), (n2:v1 {'property':'c'}) create (n1)-[n3:e1 {property:'3c'}]->(n2);
+match (n1:v1 {'property':'4'} ), (n2:v1 {'property':'d'}) create (n1)-[n3:e1 {property:'4d'}]->(n2);
+
+-- delete vertex, by readonly user
+
+SET SESSION AUTHORIZATION readonly_user;
+
+MATCH (n{'property':'1'}) WHERE NOT EXISTS ((n)-[*1]-()) return n;
+MATCH (n{'property':'1'}) WHERE NOT EXISTS ((n)-[*1]-()) delete n; -- #624 issue
+MATCH (n{'property':'1'}) WHERE NOT EXISTS ((n)-[*1]-()) return n;
+
+-- clear all
+RESET SESSION AUTHORIZATION;
+DROP GRAPH IF EXISTS graph_priv_test CASCADE;


### PR DESCRIPTION
1. Add ACL check logic before actual heap manipulation to prevent invalid access to the address.
2. The graphid and schemaid are not identical because they have different OIDs. Check ag_graph.