### PR TITLE
Fix: could not dump unrecognized node type: 59

### DIFF
--- a/src/backend/nodes/outfuncs.c
+++ b/src/backend/nodes/outfuncs.c
@@ -1063,6 +1063,17 @@ _outDijkstra(StringInfo str, const Dijkstra *node)
 }
 
 static void
+_outGraphVLE(StringInfo str, const GraphVLE *node)
+{
+	WRITE_NODE_TYPE("GRAPHVLE");
+
+	_outPlanInfo(str, (const Plan *) node);
+
+	WRITE_NODE_FIELD(subplan);
+	WRITE_NODE_FIELD(vle_rel);
+}
+
+static void
 _outNestLoopParam(StringInfo str, const NestLoopParam *node)
 {
 	WRITE_NODE_TYPE("NESTLOOPPARAM");
@@ -4703,6 +4714,9 @@ outNode(StringInfo str, const void *obj)
 				break;
 			case T_Dijkstra:
 				_outDijkstra(str, obj);
+				break;
+			case T_GraphVLE:
+				_outGraphVLE(str, obj);
 				break;
 			case T_NestLoopParam:
 				_outNestLoopParam(str, obj);


### PR DESCRIPTION
# About this PR

When a user runs a VLE query, the server prints: "WARNING: could not dump unrecognized node type: 59:". This is because there is no `_out...` function for VLE. This commit fixes that.

```
postgres=# create graph vertex_labels_simple;
SET graph_path = vertex_labels_simple;
create (:Person {name: 'a'})<-[:phone_number_of]-(:Extension {ext: 27})-[:extension_of]->(:Number {number: 1111})-[:phone_number_of]->(:Person {name: 'b'});
match p=(:person {name:'a'})-[*]-(:number) return p;
CREATE GRAPH
SET
UPDATE 7
WARNING:  could not dump unrecognized node type: 59
                                                                       p                                                                       
-----------------------------------------------------------------------------------------------------------------------------------------------
 [person[3.1]{"name": "a"},phone_number_of[4.1][5.1,3.1]{},extension[5.1]{"ext": 27},extension_of[6.1][5.1,7.1]{},number[7.1]{"number": 1111}]
(1 row)

```

# Related issue

This PR is solving issue #638.
There's no error message `Error message: ERROR: unrecognized node type: 110`

```
postgres=# CREATE ()<-[r0:T0]-() 
MATCH p0=(n0)-[*0..1]-() 
RETURN 1
;
 ?column? 
----------
 1
 1
 1
 1
(4 rows)

postgres=# match (n) return n;
        n         
------------------
 ag_vertex[1.1]{}
 ag_vertex[1.2]{}
 ag_vertex[1.3]{}
 ag_vertex[1.4]{}
(4 rows)

postgres=# CREATE ()<-[r0:T0]-() 
MATCH p0=(n0)-[*0..1]-() 
RETURN 1
;
 ?column? 
----------
 1
 1
 1
 1
 1
 1
 1
 1
(8 rows)
```


# Checklist

The regression checks has been passed.