### PR TITLE
Fix: Invalid label numbering after RENAME command

### DIFF
--- a/src/backend/commands/graphcmds.c
+++ b/src/backend/commands/graphcmds.c
@@ -42,6 +42,11 @@
 #include "utils/rel.h"
 #include "utils/syscache.h"
 #include "catalog/pg_inherits.h"
+#include "nodes/makefuncs.h"
+#include "nodes/nodes.h"
+#include "access/relation.h"
+#include "catalog/pg_attrdef.h"
+#include "utils/fmgroids.h"
 
 static ObjectAddress DefineLabel(CreateStmt *stmt, char labkind,
 								 const char *queryString, bool is_fixed_id,
@@ -53,6 +58,7 @@ static void SetMaxStatisticsTarget(Oid laboid);
 static bool IsLabel(const char *label_name, Oid namespaceId);
 static void SimpleProcessUtility(Node *node, const char *queryString,
 								 int stmt_location, int stmt_len);
+static void ReplaceLabelDefaultExpression(RenameStmt *stmt);
 
 /* See ProcessUtilitySlow() case T_CreateSchemaStmt */
 void
@@ -460,6 +466,7 @@ RenameLabel(RenameStmt *stmt)
 	table_close(rel, NoLock);
 	heap_freetuple(tup);
 
+	ReplaceLabelDefaultExpression(stmt);
 	return address;
 }
 
@@ -731,4 +738,63 @@ SimpleProcessUtility(Node *node, const char *queryString, int stmt_location,
 
 	ProcessUtility(wrapper, queryString, false, PROCESS_UTILITY_SUBCOMMAND,
 				   NULL, NULL, None_Receiver, NULL);
+}
+
+/* 
+ * Update default expression of id column
+ * See transformLabelIdDefinition()
+ */
+static void
+ReplaceLabelDefaultExpression(RenameStmt *stmt)
+{
+	AttrNumber		attnum;
+	HeapTuple		tup;
+	Form_ag_label	form_ag_label;
+	Relation 		rel;
+	FuncExpr	   *graphIdFuncExpr,
+				   *graphLabidFuncExpr;
+	char			buf[NAMEDATALEN] = {0};
+	Const		   *n;
+	Oid				graphid = get_graph_path_oid();
+
+	tup = SearchSysCacheCopy2(LABELNAMEGRAPH,
+							  CStringGetDatum(stmt->relation->relname),
+							  ObjectIdGetDatum(graphid));
+
+	if (!HeapTupleIsValid(tup))
+		elog(ERROR, "cache lookup failed for graph %u of lable name %u",
+			 graphid, stmt->relation->relname);
+
+	form_ag_label = (Form_ag_label) GETSTRUCT(tup);
+	attnum = get_attnum(form_ag_label->relid, AG_ELEM_LOCAL_ID);
+	rel = relation_open(form_ag_label->relid, AccessExclusiveLock);
+
+	graphIdFuncExpr = stringToNode(rel->rd_att->constr->defval->adbin);
+
+	/* First argument of graphid() is the graph_labid() */
+	graphLabidFuncExpr = (FuncExpr *) linitial(graphIdFuncExpr->args);
+
+	snprintf(buf, sizeof(buf), "%s.%s", stmt->relation->schemaname, 
+			 stmt->newname);
+
+	/* Create a replacement form for the graph_labid argument */
+	n = makeNode(Const);
+	n->consttype = CSTRINGOID;
+	n->consttypmod = -1;
+	n->constcollid = InvalidOid;
+	n->constlen = -2;
+	n->constbyval = false;
+	n->location = -1;
+	n->constvalue = CStringGetDatum(buf);
+
+	/* Rewrite the function expression */
+	graphLabidFuncExpr->args = list_delete_first(graphLabidFuncExpr->args);
+	graphLabidFuncExpr->args = lappend(graphLabidFuncExpr->args, n);
+
+	/* Update */
+	RemoveAttrDefault(rel->rd_id, attnum, DROP_RESTRICT, false, true);
+	StoreAttrDefault(rel, attnum, graphIdFuncExpr, true, false);
+
+	relation_close(rel, AccessExclusiveLock);
+	heap_freetuple(tup);
 }

--- a/src/test/regress/expected/cypher_dml.out
+++ b/src/test/regress/expected/cypher_dml.out
@@ -4132,6 +4132,28 @@ MATCH p=() MERGE a=(p) RETURN p;
 ERROR:  duplicate variable "p"
 LINE 1: MATCH p=() MERGE a=(p) RETURN p;
                             ^
+--
+-- AGV2-422
+--
+CREATE GRAPH rename_test;
+SET graph_path = rename_test;
+CREATE (:v1)-[:e1]->(:v1);
+MATCH (v1:v1)-[e1:e1]->(v2:v1) RETURN v1,e1,v2;
+    v1     |         e1         |    v2     
+-----------+--------------------+-----------
+ v1[3.1]{} | e1[4.1][3.1,3.2]{} | v1[3.2]{}
+(1 row)
+
+ALTER ELABEL e1 RENAME TO new_e1;
+ALTER VLABEL v1 RENAME TO new_v1;
+CREATE (:new_v1)-[:new_e1]->(:new_v1);
+MATCH (v1:new_v1)-[e1:new_e1]->(v2:new_v1) RETURN v1,e1,v2;
+      v1       |           e1           |      v2       
+---------------+------------------------+---------------
+ new_v1[3.1]{} | new_e1[4.1][3.1,3.2]{} | new_v1[3.2]{}
+ new_v1[3.3]{} | new_e1[4.2][3.3,3.4]{} | new_v1[3.4]{}
+(2 rows)
+
 -- cleanup
 DROP GRAPH srf CASCADE;
 NOTICE:  drop cascades to 5 other objects
@@ -4244,3 +4266,10 @@ drop cascades to vlabel none
 drop cascades to elabel directed
 drop cascades to vlabel base
 DROP TABLE history;
+DROP GRAPH rename_test CASCADE;
+NOTICE:  drop cascades to 5 other objects
+DETAIL:  drop cascades to sequence rename_test.ag_label_seq
+drop cascades to vlabel ag_vertex
+drop cascades to elabel ag_edge
+drop cascades to vlabel new_v1
+drop cascades to elabel new_e1

--- a/src/test/regress/sql/cypher_dml.sql
+++ b/src/test/regress/sql/cypher_dml.sql
@@ -1606,6 +1606,18 @@ MERGE ()-[r:idk]->() MERGE ()-[r {k:1}]->() RETURN count (r);
 MATCH p=() MERGE p=() RETURN p;
 MATCH p=() MERGE a=(p) RETURN p;
 
+--
+-- AGV2-422
+--
+CREATE GRAPH rename_test;
+SET graph_path = rename_test;
+CREATE (:v1)-[:e1]->(:v1);
+MATCH (v1:v1)-[e1:e1]->(v2:v1) RETURN v1,e1,v2;
+ALTER ELABEL e1 RENAME TO new_e1;
+ALTER VLABEL v1 RENAME TO new_v1;
+CREATE (:new_v1)-[:new_e1]->(:new_v1);
+MATCH (v1:new_v1)-[e1:new_e1]->(v2:new_v1) RETURN v1,e1,v2;
+
 -- cleanup
 
 DROP GRAPH srf CASCADE;
@@ -1631,3 +1643,5 @@ DROP ELABEL doc;
 DROP GRAPH agens CASCADE;
 
 DROP TABLE history;
+
+DROP GRAPH rename_test CASCADE;


### PR DESCRIPTION
# What is this PR for

1. After executing the ALTER LABEL RENAME command, the target label ID was not properly updated when attempting to insert into that label. This PR fix that bug.

~~2. Some logic still needs to be refined later; this is marked as AgensTodo:.~~

# Checklist
regression checks done