### PR TITLE
Allow users to control enable_graph_dml backend variable

### DIFF
--- a/src/backend/catalog/ag_graph.c
+++ b/src/backend/catalog/ag_graph.c
@@ -30,7 +30,7 @@
 
 /* a global variable for the GUC variable */
 char	   *graph_path = NULL;
-bool		enableGraphDML = false;
+bool		enable_graph_dml = false;
 bool		cypher_allow_unsafe_ddl = false;
 
 /* Potentially set by pg_upgrade_support functions */

--- a/src/backend/commands/graphcmds.c
+++ b/src/backend/commands/graphcmds.c
@@ -672,6 +672,7 @@ deleteRelatedEdges(const char *vlab)
 	Oid			agedge;
 	ListCell   *lc;
 	List	   *edges = NIL;
+	bool 		temp_enable_graph_dml = enable_graph_dml;
 
 	graphoid = get_graph_path_oid();
 	vlabid = get_labname_labid(vlab, graphoid);
@@ -709,12 +710,12 @@ deleteRelatedEdges(const char *vlab)
 		if (ret != SPI_OK_CONNECT)
 			elog(ERROR, "deleteRelatedEdges: SPI_connect returned %d", ret);
 
-		enableGraphDML = true;
+		enable_graph_dml = true;
 		ret = SPI_execute(sql.data, false, 0);
 		if (ret != SPI_OK_DELETE)
 			elog(ERROR, "deleteRelatedEdges: SPI_execute returned %d: %s",
 				 ret, sql.data);
-		enableGraphDML = false;
+		enable_graph_dml = temp_enable_graph_dml;
 
 		ret = SPI_finish();
 		if (ret != SPI_OK_FINISH)

--- a/src/backend/parser/analyze.c
+++ b/src/backend/parser/analyze.c
@@ -503,7 +503,7 @@ transformDeleteStmt(ParseState *pstate, DeleteStmt *stmt)
 
 	qry->commandType = CMD_DELETE;
 
-	if (RangeVarIsLabel(stmt->relation) && !enableGraphDML)
+	if (RangeVarIsLabel(stmt->relation) && !enable_graph_dml)
 		elog(ERROR, "DML query to graph objects is not allowed");
 
 	/* process the WITH clause independently of all else */
@@ -588,7 +588,7 @@ transformInsertStmt(ParseState *pstate, InsertStmt *stmt)
 	bool		isOnConflictUpdate;
 	AclMode		targetPerms;
 
-	if (RangeVarIsLabel(stmt->relation) && !enableGraphDML)
+	if (RangeVarIsLabel(stmt->relation) && !enable_graph_dml)
 		elog(ERROR, "DML query to graph objects is not allowed");
 
 	/* There can't be any outer WITH to worry about */
@@ -2404,7 +2404,7 @@ transformUpdateStmt(ParseState *pstate, UpdateStmt *stmt)
 	ParseNamespaceItem *nsitem;
 	Node	   *qual;
 
-	if (RangeVarIsLabel(stmt->relation) && !enableGraphDML)
+	if (RangeVarIsLabel(stmt->relation) && !enable_graph_dml)
 		elog(ERROR, "DML query to graph objects is not allowed");
 
 	qry->commandType = CMD_UPDATE;

--- a/src/backend/tcop/pquery.c
+++ b/src/backend/tcop/pquery.c
@@ -846,9 +846,6 @@ PortalRun(Portal portal, long count, bool isTopLevel, bool run_once,
 			CurrentResourceOwner = saveResourceOwner;
 		PortalContext = savePortalContext;
 
-		/* todo: Is it using now? */
-		enableGraphDML = false;
-
 		PG_RE_THROW();
 	}
 	PG_END_TRY();

--- a/src/backend/utils/misc/guc_tables.c
+++ b/src/backend/utils/misc/guc_tables.c
@@ -2058,6 +2058,17 @@ struct config_bool ConfigureNamesBool[] =
 		NULL, NULL, NULL
 	},
 
+	{
+		{"enable_graph_dml", PGC_SUSET, CLIENT_CONN_STATEMENT,
+			gettext_noop("Allows using SQL DML queries on graph objects."),
+			NULL,
+			GUC_SUPERUSER_ONLY
+		},
+		&enable_graph_dml,
+		false,
+		NULL, NULL, NULL
+	},
+
 	/* End-of-list marker */
 	{
 		{NULL, 0, 0, NULL, NULL}, NULL, false, NULL, NULL, NULL

--- a/src/backend/utils/misc/postgresql.conf.sample
+++ b/src/backend/utils/misc/postgresql.conf.sample
@@ -820,6 +820,7 @@
 #enable_eager = off
 #auto_gather_graphmeta = off
 #cypher_allow_unsafe_ddl = off
+#enable_graph_dml = off
 #allow_null_properties = off
 #enable_multiple_update = off
 #graph_path = ''                    # graph/schema names

--- a/src/include/catalog/ag_graph_fn.h
+++ b/src/include/catalog/ag_graph_fn.h
@@ -13,7 +13,7 @@
 #include "nodes/parsenodes.h"
 
 extern char *graph_path;
-extern bool enableGraphDML;
+extern bool enable_graph_dml;
 extern bool cypher_allow_unsafe_ddl;
 
 extern char *get_graph_path(bool lookup_cache);

--- a/src/test/regress/expected/sysviews.out
+++ b/src/test/regress/expected/sysviews.out
@@ -115,6 +115,7 @@ select name, setting from pg_settings where name like 'enable%';
  enable_bitmapscan              | on
  enable_eager                   | on
  enable_gathermerge             | on
+ enable_graph_dml               | off
  enable_hashagg                 | on
  enable_hashjoin                | on
  enable_incremental_sort        | on
@@ -134,7 +135,7 @@ select name, setting from pg_settings where name like 'enable%';
  enable_seqscan                 | on
  enable_sort                    | on
  enable_tidscan                 | on
-(23 rows)
+(24 rows)
 
 -- Test that the pg_timezone_names and pg_timezone_abbrevs views are
 -- more-or-less working.  We can't test their contents in any great detail


### PR DESCRIPTION
- This allows SQL DML queries on graph objects.
- Can only be controlled by superuser, since there is a possibilty of graph corruption using DML quries on graph objects.