### PR TITLE
fix: error referencing non-returned vars in ORDER BY

### DIFF
--- a/src/backend/parser/parse_cypher_expr.c
+++ b/src/backend/parser/parse_cypher_expr.c
@@ -2603,36 +2603,73 @@ transformCypherOrderBy(ParseState *pstate, List *sortitems, List **targetlist)
 	List	   *sortgroups = NIL;
 	ListCell   *lsi;
 
-	/* See findTargetlistEntrySQL99() */
+	/* See findTargetlistEntrySQL92()/findTargetlistEntrySQL99() */
 	foreach(lsi, sortitems)
 	{
 		SortBy	   *sortby = lfirst(lsi);
-		Node	   *expr;
+		Node	   *expr = NULL;
 		ListCell   *lt;
 		TargetEntry *te = NULL;
 
-		expr = transformCypherExpr(pstate, sortby->node, exprKind);
-
-		foreach(lt, *targetlist)
+		/*
+		 * First, if the sort item is a bare name, try to match it to a
+		 * RETURN/WITH alias, as SQL does (findTargetlistEntrySQL92).  This
+		 * lets "RETURN p.name AS name ORDER BY name" order by the projected
+		 * column.
+		 */
+		if (sortby->node && IsA(sortby->node, ColumnRef))
 		{
-			TargetEntry *tmp;
-			Node	   *texpr;
+			ColumnRef  *cref = (ColumnRef *) sortby->node;
 
-			tmp = lfirst(lt);
-			texpr = strip_implicit_coercions((Node *) tmp->expr);
-			if (equal(texpr, expr))
+			if (list_length(cref->fields) == 1 &&
+				IsA(linitial(cref->fields), String))
 			{
-				te = tmp;
-				break;
+				char	   *colname = strVal(linitial(cref->fields));
+
+				foreach(lt, *targetlist)
+				{
+					TargetEntry *tmp = lfirst(lt);
+
+					if (tmp->resname && strcmp(tmp->resname, colname) == 0)
+					{
+						te = tmp;
+						break;
+					}
+				}
 			}
 		}
 
+		/*
+		 * Otherwise transform the sort expression.  If it matches an item
+		 * already in the target list, reuse that entry; if not, add it as a
+		 * resjunk entry so that ORDER BY can reference expressions that are
+		 * not in the RETURN list (e.g. "RETURN p.name ORDER BY p.age").
+		 */
 		if (te == NULL)
 		{
-			te = transformTargetEntry(pstate, sortby->node, expr, exprKind,
-									  NULL, true);
+			expr = transformCypherExpr(pstate, sortby->node, exprKind);
 
-			*targetlist = lappend(*targetlist, te);
+			foreach(lt, *targetlist)
+			{
+				TargetEntry *tmp;
+				Node	   *texpr;
+
+				tmp = lfirst(lt);
+				texpr = strip_implicit_coercions((Node *) tmp->expr);
+				if (equal(texpr, expr))
+				{
+					te = tmp;
+					break;
+				}
+			}
+
+			if (te == NULL)
+			{
+				te = transformTargetEntry(pstate, sortby->node, expr, exprKind,
+										  NULL, true);
+
+				*targetlist = lappend(*targetlist, te);
+			}
 		}
 
 		sortgroups = addTargetToSortList(pstate, te, sortgroups, *targetlist,

--- a/src/backend/parser/parse_graph.c
+++ b/src/backend/parser/parse_graph.c
@@ -12,6 +12,7 @@
 
 #include "access/genam.h"
 #include "access/htup_details.h"
+#include "access/stratnum.h"
 #include "access/table.h"
 #include "ag_const.h"
 #include "catalog/ag_edge_d.h"
@@ -28,6 +29,7 @@
 #include "nodes/graphnodes.h"
 #include "nodes/makefuncs.h"
 #include "nodes/nodeFuncs.h"
+#include "optimizer/optimizer.h"
 #include "parser/analyze.h"
 #include "parser/parse_agg.h"
 #include "parser/parse_clause.h"
@@ -142,6 +144,7 @@ typedef struct
 
 /* projection (RETURN and WITH) */
 static void checkNameInItems(ParseState *pstate, List *items, List *targetList);
+static void updateSortOperatorsForJsonb(List *sortClause, List *targetList);
 
 /* MATCH - OPTIONAL */
 static ParseNamespaceItem *transformMatchOptional(ParseState *pstate,
@@ -454,6 +457,60 @@ transformCypherSubPattern(ParseState *pstate, CypherSubPattern *subpat)
 	return qry;
 }
 
+/*
+ * After the RETURN target list is coerced to jsonb (resolveItemList), any sort
+ * key that points at a coerced target entry still carries the comparison
+ * operators chosen for the entry's original type.  Re-point such sort keys at
+ * the operators for the entry's final (jsonb) type so that ordering matches
+ * the returned values.  Sort keys whose type did not change keep their original
+ * operators.
+ */
+static void
+updateSortOperatorsForJsonb(List *sortClause, List *targetList)
+{
+	ListCell   *lc;
+
+	foreach(lc, sortClause)
+	{
+		SortGroupClause *sortcl = (SortGroupClause *) lfirst(lc);
+		TargetEntry *tle;
+		Oid			restype;
+		Oid			sortop;
+		Oid			eqop;
+		bool		hashable;
+		Oid			opfamily;
+		Oid			opcintype;
+		int16		strategy;
+
+		tle = get_sortgroupref_tle(sortcl->tleSortGroupRef, targetList);
+		if (tle == NULL)
+			continue;
+
+		restype = exprType((Node *) tle->expr);
+
+		/* What ordering direction does the current operator represent? */
+		if (!get_ordering_op_properties(sortcl->sortop,
+										&opfamily, &opcintype, &strategy))
+			continue;
+
+		if (strategy == BTLessStrategyNumber)
+			get_sort_group_operators(restype,
+									 true, true, false,
+									 &sortop, &eqop, NULL,
+									 &hashable);
+		else if (strategy == BTGreaterStrategyNumber)
+			get_sort_group_operators(restype,
+									 false, true, true,
+									 NULL, &eqop, &sortop,
+									 &hashable);
+		else
+			continue;
+
+		sortcl->eqop = eqop;
+		sortcl->sortop = sortop;
+	}
+}
+
 Query *
 transformCypherProjection(ParseState *pstate, CypherClause *clause)
 {
@@ -481,57 +538,16 @@ transformCypherProjection(ParseState *pstate, CypherClause *clause)
 		qual = transformCypherWhere(pstate, where, EXPR_KIND_WHERE);
 		qual = resolve_future_vertex(pstate, qual, 0);
 	}
-	else if (detail->distinct != NULL || detail->order != NULL ||
-			 detail->skip != NULL || detail->limit != NULL)
-	{
-		List	   *distinct = detail->distinct;
-		List	   *order = detail->order;
-		Node	   *skip = detail->skip;
-		Node	   *limit = detail->limit;
-
-		/*
-		 * detach options so that this function passes through this if
-		 * statement when the function is called again recursively
-		 */
-		detail->distinct = NIL;
-		detail->order = NIL;
-		detail->skip = NULL;
-		detail->limit = NULL;
-		nsitem = transformClause(pstate, (Node *) clause);
-		detail->distinct = distinct;
-		detail->order = order;
-		detail->skip = skip;
-		detail->limit = limit;
-
-		qry->targetList = makeTargetListFromNSItem(pstate, nsitem);
-
-		qry->sortClause = transformCypherOrderBy(pstate, order,
-												 &qry->targetList);
-
-		if (distinct == NIL)
-		{
-			/* intentionally blank, do nothing */
-		}
-		else
-		{
-			Assert(linitial(distinct) == NULL);
-
-			qry->distinctClause = transformDistinctClause(pstate,
-														  &qry->targetList,
-														  qry->sortClause,
-														  false);
-		}
-
-		qry->limitOffset = transformCypherLimit(pstate, skip, EXPR_KIND_OFFSET,
-												"SKIP");
-		qry->limitOffset = resolve_future_vertex(pstate, qry->limitOffset, 0);
-
-		qry->limitCount = transformCypherLimit(pstate, limit, EXPR_KIND_LIMIT,
-											   "LIMIT");
-		qry->limitCount = resolve_future_vertex(pstate, qry->limitCount, 0);
-	}
 	else
 	{
+		/*
+		 * Build the projection and apply ORDER BY / DISTINCT / SKIP / LIMIT at
+		 * the same query level as the pattern, rather than wrapping the
+		 * projection in a subquery.  This lets ORDER BY reference variables
+		 * that are not in the RETURN list (e.g. "RETURN p.name ORDER BY
+		 * p.age"); transformCypherOrderBy() adds such sort keys as resjunk
+		 * target entries.
+		 */
 		if (clause->prev != NULL)
 			transformClause(pstate, clause->prev);
 
@@ -540,6 +556,28 @@ transformCypherProjection(ParseState *pstate, CypherClause *clause)
 
 		if (detail->kind == CP_WITH)
 			checkNameInItems(pstate, detail->items, qry->targetList);
+
+		if (detail->order != NULL)
+			qry->sortClause = transformCypherOrderBy(pstate, detail->order,
+													 &qry->targetList);
+
+		if (detail->distinct != NULL)
+		{
+			Assert(linitial(detail->distinct) == NULL);
+
+			qry->distinctClause = transformDistinctClause(pstate,
+														  &qry->targetList,
+														  qry->sortClause,
+														  false);
+		}
+
+		qry->limitCount = transformCypherLimit(pstate, detail->limit,
+											   EXPR_KIND_LIMIT, "LIMIT");
+		qry->limitCount = resolve_future_vertex(pstate, qry->limitCount, 0);
+
+		qry->limitOffset = transformCypherLimit(pstate, detail->skip,
+												EXPR_KIND_OFFSET, "SKIP");
+		qry->limitOffset = resolve_future_vertex(pstate, qry->limitOffset, 0);
 
 		qry->groupClause = generateGroupClause(pstate, &qry->targetList,
 											   qry->sortClause);
@@ -581,7 +619,17 @@ transformCypherProjection(ParseState *pstate, CypherClause *clause)
 	qual = qualAndExpr(qual, pstate->p_resolved_qual);
 
 	if (detail->kind == CP_RETURN)
+	{
 		resolveItemList(pstate, qry->targetList);
+
+		/*
+		 * resolveItemList() coerces returned target entries to jsonb, which
+		 * can change the type a sort key resolves to; refresh the sort
+		 * operators so they match the final (jsonb) type.
+		 */
+		if (qry->sortClause != NIL)
+			updateSortOperatorsForJsonb(qry->sortClause, qry->targetList);
+	}
 
 	qry->rtable = pstate->p_rtable;
 	qry->jointree = makeFromExpr(pstate->p_joinlist, qual);
@@ -3770,6 +3818,9 @@ static Node *
 resolve_future_vertex(ParseState *pstate, Node *node, int flags)
 {
 	resolve_future_vertex_context ctx;
+
+	if (node == NULL)
+		return NULL;
 
 	ctx.pstate = pstate;
 	ctx.flags = flags;

--- a/src/test/regress/expected/cypher_dml.out
+++ b/src/test/regress/expected/cypher_dml.out
@@ -4582,7 +4582,99 @@ RETURN t;
  test[3.1]{}
 (1 row)
 
+--
+-- AGV2-324: ORDER BY may reference variables/expressions not in RETURN
+--
+CREATE GRAPH ag324;
+SET graph_path = ag324;
+CREATE (:person {name: 'Alice', age: 30}),
+       (:person {name: 'Bob', age: 5}),
+       (:person {name: 'Charlie', age: 100}),
+       (:person {name: 'Dave', age: 30});
+-- order by a property that is not in the RETURN list (numeric, not lexical)
+MATCH (p:person) RETURN p.name AS name ORDER BY p.age;
+   name    
+-----------
+ "Bob"
+ "Alice"
+ "Dave"
+ "Charlie"
+(4 rows)
+
+MATCH (p:person) RETURN p.name AS name ORDER BY p.age DESC;
+   name    
+-----------
+ "Charlie"
+ "Alice"
+ "Dave"
+ "Bob"
+(4 rows)
+
+-- order by a RETURN alias
+MATCH (p:person) RETURN p.name AS name ORDER BY name;
+   name    
+-----------
+ "Alice"
+ "Bob"
+ "Charlie"
+ "Dave"
+(4 rows)
+
+-- mix of alias and non-returned expression
+MATCH (p:person) RETURN p.name AS name ORDER BY p.age, name;
+   name    
+-----------
+ "Bob"
+ "Alice"
+ "Dave"
+ "Charlie"
+(4 rows)
+
+MATCH (p:person) RETURN p.name AS name ORDER BY name, p.age DESC;
+   name    
+-----------
+ "Alice"
+ "Bob"
+ "Charlie"
+ "Dave"
+(4 rows)
+
+-- a returned key keeps jsonb (numeric) ordering after coercion
+MATCH (p:person) RETURN p.name AS name, p.age AS age ORDER BY age;
+   name    | age 
+-----------+-----
+ "Bob"     | 5
+ "Alice"   | 30
+ "Dave"    | 30
+ "Charlie" | 100
+(4 rows)
+
+-- DISTINCT together with ORDER BY
+MATCH (p:person) RETURN DISTINCT p.age AS age ORDER BY age DESC;
+ age 
+-----
+ 100
+ 30
+ 5
+(3 rows)
+
+-- ORDER BY an aggregate: count() is bigint and is coerced to jsonb in the
+-- target list, so the sort operator must follow the final (jsonb) type
+MATCH (p:person) RETURN p.age AS age, count(*) AS cnt ORDER BY cnt, age;
+ age | cnt 
+-----+-----
+ 5   | 1
+ 100 | 1
+ 30  | 2
+(3 rows)
+
 -- cleanup
+DROP GRAPH ag324 CASCADE;
+NOTICE:  drop cascades to 4 other objects
+DETAIL:  drop cascades to sequence ag324.ag_label_seq
+drop cascades to vlabel ag_vertex
+drop cascades to elabel ag_edge
+drop cascades to vlabel person
 DROP GRAPH agv2_308 CASCADE;
 NOTICE:  drop cascades to 4 other objects
 DETAIL:  drop cascades to sequence agv2_308.ag_label_seq

--- a/src/test/regress/expected/cypher_shortestpath2.out
+++ b/src/test/regress/expected/cypher_shortestpath2.out
@@ -15378,79 +15378,82 @@ match p = shortestpath( (o1:o)<-[:e*1..2]->(o2:o) ) where o1.id = 1 and o1.id = 
 
 explain ( analyze false, verbose true, costs false, buffers false, timing false )
 match (s1:s), (s2:s) return s1.id as s1id, s2.id as s2id, ids(nodes(shortestpath((s1)-[:e]->(s2)))) order by s1id, s2id;
-                                                  QUERY PLAN                                                  
---------------------------------------------------------------------------------------------------------------
- Sort
-   Output: (s1.properties.'id'::text), (s2.properties.'id'::text), (ids(nodes((SubPlan 5))))
-   Sort Key: (s1.properties.'id'::text), (s2.properties.'id'::text)
-   ->  Nested Loop
-         Output: s1.properties.'id'::text, s2.properties.'id'::text, ids(nodes((SubPlan 5)))
-         ->  Seq Scan on shortestpath.s s1
-               Output: s1.id, s1.properties
-         ->  Seq Scan on shortestpath.s s2
-               Output: s2.id, s2.properties
-         SubPlan 5
-           ->  Subquery Scan on _d
-                 Output: ROW((SubPlan 2), COALESCE((SubPlan 4), '[]'::edge[]))::graphpath
-                 ->  Shortestpath VLE [1..1]
-                       Output: shortestpath_graphids(), shortestpath_rowids()
-                       Hash Cond: (e_1."end" = e_2.start)
-                       ->  Hash2Side
+                                               QUERY PLAN                                               
+--------------------------------------------------------------------------------------------------------
+ Result
+   Output: (s1.properties.'id'::text), (s2.properties.'id'::text), ids(nodes((SubPlan 5)))
+   ->  Incremental Sort
+         Output: (s1.properties.'id'::text), (s2.properties.'id'::text), s1.id, s2.id
+         Sort Key: (s1.properties.'id'::text), (s2.properties.'id'::text)
+         Presorted Key: (s1.properties.'id'::text)
+         ->  Nested Loop
+               Output: s1.properties.'id'::text, s2.properties.'id'::text, s1.id, s2.id
+               ->  Index Scan using s_id_idx on shortestpath.s s1
+                     Output: s1.id, s1.properties
+               ->  Seq Scan on shortestpath.s s2
+                     Output: s2.id, s2.properties
+   SubPlan 5
+     ->  Subquery Scan on _d
+           Output: ROW((SubPlan 2), COALESCE((SubPlan 4), '[]'::edge[]))::graphpath
+           ->  Shortestpath VLE [1..1]
+                 Output: shortestpath_graphids(), shortestpath_rowids()
+                 Hash Cond: (e_1."end" = e_2.start)
+                 ->  Hash2Side
+                       Output: e_1."end", e_1.tableoid, e_1.ctid
+                       ->  Index Scan using e_start_idx on shortestpath.e e_1
                              Output: e_1."end", e_1.tableoid, e_1.ctid
-                             ->  Index Scan using e_start_idx on shortestpath.e e_1
-                                   Output: e_1."end", e_1.tableoid, e_1.ctid
-                                   Index Cond: (e_1.start = s1.id)
-                       ->  Hash2Side
+                             Index Cond: (e_1.start = s1.id)
+                 ->  Hash2Side
+                       Output: e_2.start, e_2.tableoid, e_2.ctid
+                       ->  Index Scan using e_end_idx on shortestpath.e e_2
                              Output: e_2.start, e_2.tableoid, e_2.ctid
-                             ->  Index Scan using e_end_idx on shortestpath.e e_2
-                                   Output: e_2.start, e_2.tableoid, e_2.ctid
-                                   Index Cond: (e_2."end" = s2.id)
-                 SubPlan 2
-                   ->  Aggregate
-                         Output: array_agg((SubPlan 1))
-                         ->  Function Scan on pg_catalog.unnest vid
-                               Output: vid.vid
-                               Function Call: unnest(_d.vids)
-                         SubPlan 1
-                           ->  Result
-                                 Output: ROW(ag_vertex.id, ag_vertex.properties, ag_vertex.ctid)::vertex
-                                 ->  Append
-                                       ->  Seq Scan on shortestpath.ag_vertex ag_vertex_1
-                                             Output: ag_vertex_1.id, ag_vertex_1.properties, ag_vertex_1.ctid
-                                             Filter: (ag_vertex_1.id = vid.vid)
-                                       ->  Seq Scan on shortestpath.vp ag_vertex_2
-                                             Output: ag_vertex_2.id, ag_vertex_2.properties, ag_vertex_2.ctid
-                                             Filter: (ag_vertex_2.id = vid.vid)
-                                       ->  Seq Scan on shortestpath.o ag_vertex_3
-                                             Output: ag_vertex_3.id, ag_vertex_3.properties, ag_vertex_3.ctid
-                                             Filter: (ag_vertex_3.id = vid.vid)
-                                       ->  Seq Scan on shortestpath.s ag_vertex_4
-                                             Output: ag_vertex_4.id, ag_vertex_4.properties, ag_vertex_4.ctid
-                                             Filter: (ag_vertex_4.id = vid.vid)
-                                       ->  Seq Scan on shortestpath.c ag_vertex_5
-                                             Output: ag_vertex_5.id, ag_vertex_5.properties, ag_vertex_5.ctid
-                                             Filter: (ag_vertex_5.id = vid.vid)
-                                       ->  Index Scan using l_pkey on shortestpath.l ag_vertex_6
-                                             Output: ag_vertex_6.id, ag_vertex_6.properties, ag_vertex_6.ctid
-                                             Index Cond: (ag_vertex_6.id = vid.vid)
-                                       ->  Index Scan using r_pkey on shortestpath.r ag_vertex_7
-                                             Output: ag_vertex_7.id, ag_vertex_7.properties, ag_vertex_7.ctid
-                                             Index Cond: (ag_vertex_7.id = vid.vid)
-                                       ->  Seq Scan on shortestpath.vc ag_vertex_8
-                                             Output: ag_vertex_8.id, ag_vertex_8.properties, ag_vertex_8.ctid
-                                             Filter: (ag_vertex_8.id = vid.vid)
-                 SubPlan 4
-                   ->  Aggregate
-                         Output: array_agg((SubPlan 3))
-                         ->  Function Scan on pg_catalog.unnest eid
-                               Output: eid.eid
-                               Function Call: unnest(_d.eids)
-                         SubPlan 3
-                           ->  Tid Scan on shortestpath.e
-                                 Output: ROW(e.id, e.start, e."end", e.properties, e.ctid)::edge
-                                 TID Cond: (e.ctid = rowid_ctid(eid.eid))
-                                 Filter: (e.tableoid = rowid_tableoid(eid.eid))
-(70 rows)
+                             Index Cond: (e_2."end" = s2.id)
+           SubPlan 2
+             ->  Aggregate
+                   Output: array_agg((SubPlan 1))
+                   ->  Function Scan on pg_catalog.unnest vid
+                         Output: vid.vid
+                         Function Call: unnest(_d.vids)
+                   SubPlan 1
+                     ->  Result
+                           Output: ROW(ag_vertex.id, ag_vertex.properties, ag_vertex.ctid)::vertex
+                           ->  Append
+                                 ->  Seq Scan on shortestpath.ag_vertex ag_vertex_1
+                                       Output: ag_vertex_1.id, ag_vertex_1.properties, ag_vertex_1.ctid
+                                       Filter: (ag_vertex_1.id = vid.vid)
+                                 ->  Seq Scan on shortestpath.vp ag_vertex_2
+                                       Output: ag_vertex_2.id, ag_vertex_2.properties, ag_vertex_2.ctid
+                                       Filter: (ag_vertex_2.id = vid.vid)
+                                 ->  Seq Scan on shortestpath.o ag_vertex_3
+                                       Output: ag_vertex_3.id, ag_vertex_3.properties, ag_vertex_3.ctid
+                                       Filter: (ag_vertex_3.id = vid.vid)
+                                 ->  Seq Scan on shortestpath.s ag_vertex_4
+                                       Output: ag_vertex_4.id, ag_vertex_4.properties, ag_vertex_4.ctid
+                                       Filter: (ag_vertex_4.id = vid.vid)
+                                 ->  Seq Scan on shortestpath.c ag_vertex_5
+                                       Output: ag_vertex_5.id, ag_vertex_5.properties, ag_vertex_5.ctid
+                                       Filter: (ag_vertex_5.id = vid.vid)
+                                 ->  Index Scan using l_pkey on shortestpath.l ag_vertex_6
+                                       Output: ag_vertex_6.id, ag_vertex_6.properties, ag_vertex_6.ctid
+                                       Index Cond: (ag_vertex_6.id = vid.vid)
+                                 ->  Index Scan using r_pkey on shortestpath.r ag_vertex_7
+                                       Output: ag_vertex_7.id, ag_vertex_7.properties, ag_vertex_7.ctid
+                                       Index Cond: (ag_vertex_7.id = vid.vid)
+                                 ->  Seq Scan on shortestpath.vc ag_vertex_8
+                                       Output: ag_vertex_8.id, ag_vertex_8.properties, ag_vertex_8.ctid
+                                       Filter: (ag_vertex_8.id = vid.vid)
+           SubPlan 4
+             ->  Aggregate
+                   Output: array_agg((SubPlan 3))
+                   ->  Function Scan on pg_catalog.unnest eid
+                         Output: eid.eid
+                         Function Call: unnest(_d.eids)
+                   SubPlan 3
+                     ->  Tid Scan on shortestpath.e
+                           Output: ROW(e.id, e.start, e."end", e.properties, e.ctid)::edge
+                           TID Cond: (e.ctid = rowid_ctid(eid.eid))
+                           Filter: (e.tableoid = rowid_tableoid(eid.eid))
+(73 rows)
 
 explain ( analyze false, verbose true, costs false, buffers false, timing false )
 match (c1:c), (c2:c) where c1.id >= 11 and c1.id <= 19 and c2.id >= 11 and c2.id <= 19 return c1.id as c1id, c2.id as c2id, allshortestpaths((c1)-[:e*]->(c2)) order by c1id, c2id;

--- a/src/test/regress/sql/cypher_dml.sql
+++ b/src/test/regress/sql/cypher_dml.sql
@@ -1690,8 +1690,40 @@ MATCH (t:test)
 SET t += row.id
 RETURN t;
 
+--
+-- AGV2-324: ORDER BY may reference variables/expressions not in RETURN
+--
+CREATE GRAPH ag324;
+SET graph_path = ag324;
+CREATE (:person {name: 'Alice', age: 30}),
+       (:person {name: 'Bob', age: 5}),
+       (:person {name: 'Charlie', age: 100}),
+       (:person {name: 'Dave', age: 30});
+
+-- order by a property that is not in the RETURN list (numeric, not lexical)
+MATCH (p:person) RETURN p.name AS name ORDER BY p.age;
+MATCH (p:person) RETURN p.name AS name ORDER BY p.age DESC;
+
+-- order by a RETURN alias
+MATCH (p:person) RETURN p.name AS name ORDER BY name;
+
+-- mix of alias and non-returned expression
+MATCH (p:person) RETURN p.name AS name ORDER BY p.age, name;
+MATCH (p:person) RETURN p.name AS name ORDER BY name, p.age DESC;
+
+-- a returned key keeps jsonb (numeric) ordering after coercion
+MATCH (p:person) RETURN p.name AS name, p.age AS age ORDER BY age;
+
+-- DISTINCT together with ORDER BY
+MATCH (p:person) RETURN DISTINCT p.age AS age ORDER BY age DESC;
+
+-- ORDER BY an aggregate: count() is bigint and is coerced to jsonb in the
+-- target list, so the sort operator must follow the final (jsonb) type
+MATCH (p:person) RETURN p.age AS age, count(*) AS cnt ORDER BY cnt, age;
+
 -- cleanup
 
+DROP GRAPH ag324 CASCADE;
 DROP GRAPH agv2_308 CASCADE;
 DROP GRAPH srf CASCADE;
 DROP GRAPH impload CASCADE;


### PR DESCRIPTION
Cypher ORDER BY could only reference columns that appeared in RETURN, because transformCypherProjection wrapped the projection in a subquery and applied ORDER BY on the outer level, where only the projected columns are visible (e.g. "RETURN p.name ORDER BY p.age" failed).

Apply ORDER BY / DISTINCT / SKIP / LIMIT at the same query level as the pattern instead of wrapping the projection in a subquery, and resolve sort items SQL-style: match a RETURN alias first, then an existing target expression, otherwise add the sort expression as a resjunk target entry. After the returned target list is coerced to jsonb, refresh the sort operators so they match the final (jsonb) type.

Removing the subquery wrapper also yields tighter plans (inline Incremental Sort instead of a Sort over a SubqueryScan); the cypher_shortestpath2 expected plan is updated accordingly.

Fixes AGV2-324